### PR TITLE
Read DTC and Clear DTC endpoint fixed

### DIFF
--- a/rest_api/actions/base_actions.py
+++ b/rest_api/actions/base_actions.py
@@ -115,7 +115,7 @@ class Action(GF):
             # First Frame (starts with 0x10)
             if msg.data[0] == 0x10:
                 total_data_length = msg.data[1]  # Total length from the first frame (byte 1 and 2)
-                collected_data = msg.data[2:]  # Store the data portion starting from byte 3
+                collected_data = msg.data[1:]  # Store the data portion starting from byte 3
                 log_info_message(logger, f"[Collect Response] First frame received. \
                                  Total length expected: {total_data_length}, \
                                  Data: {[hex(byte) for byte in collected_data]}")

--- a/rest_api/actions/generate_frames.py
+++ b/rest_api/actions/generate_frames.py
@@ -61,7 +61,7 @@ class GenerateFrame(CanBridge):
         self.__generate_long_response(id, 0x62, identifier, response, first_frame)
 
     def request_read_dtc_information(self, id, sub_funct, dtc_status_mask):
-        data = [4, 0x19, sub_funct, dtc_status_mask]
+        data = [3, 0x19, sub_funct, dtc_status_mask]
         self.send(id, data)
 
     def read_memory_by_adress(self, id, memory_address, memory_size, response=[]):


### PR DESCRIPTION
- Updated the read_dtc function to correctly format JSON for the report_dtcs subfunction and fixed the bug causing the 'nonetype object cannot be interpreted as an integer' error when subfunction 2 was called without reading any DTCs.
- Added support for the clear_dtc_info endpoint to accept a DTC group as a parameter for clearing.

## Trello link [here](https://trello.com/c/CHLpcUiI/110-readdtccleardtc-endpoint-improve)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
