### PR TITLE
Api ota_status route + mocking tests read/write

### DIFF
--- a/rest_api/actions/generate_frames.py
+++ b/rest_api/actions/generate_frames.py
@@ -273,9 +273,9 @@ class GenerateFrame(CanBridge):
         data = [0x05, 0x31, 0x01, 0x02, 0x01, version_byte]
         self.send_frame(id, data)
 
-    def request_update_status(self, func):
-        data = [0x01, func]
-        _id = (0x00 << 16) + (0xFA << 8) + 0x10
+    def request_update_status(self, ecu_id):
+        data = [0x01, 0x32]
+        _id = (0x00 << 16) + (0xFA << 8) + ecu_id
         self.send_frame(_id, data)
 
     def __generate_long_response(self, id, sid, identifier, response , first_frame):

--- a/rest_api/actions/update_action.py
+++ b/rest_api/actions/update_action.py
@@ -205,9 +205,6 @@ class Updates(Action):
         if frame_response.data[1] != 0x71:
             log_info_message(logger, "Update failed at install step.")
             return
-        if frame_response.data[1] != 0x72:
-            log_info_message(logger, "Failed request update ota status.")
-            return
 
     def _verify_version(self):
         """

--- a/rest_api/actions/update_action.py
+++ b/rest_api/actions/update_action.py
@@ -199,6 +199,11 @@ class Updates(Action):
         frame_response = self._passive_response(ROUTINE_CONTROL, "Error at install routine.")
         if frame_response.data[1] != 0x71:
             log_info_message(logger, "Update failed at install step.")
+        self.get_ota_update_state(api_target_id)
+        frame_response =self.passive_response(REQUEST_UPDATE_STATUS , "Error at verify data routine.")
+        if frame_response.data[1] != 0x72:
+            log_info_message(logger, "Failed request update ota status.")
+            return
 
     def _verify_version(self):
         """

--- a/rest_api/actions/update_action.py
+++ b/rest_api/actions/update_action.py
@@ -3,22 +3,22 @@ from configs.data_identifiers import *
 import time
 
 OTA_UPDATE_STATES = {
-    0x00: "IDLE",
-    0x10: "INIT",
-    0x20: "READY",
-    0x30: "PROCESSING",
-    0x31: "PROCESSING_TRANSFER_COMPLETE",
-    0x32: "PROCESSING_TRANSFER_FAILED",
-    0x40: "WAIT",
-    0x41: "WAIT_DOWNLOAD_COMPLETED",
-    0x42: "WAIT_DOWNLOAD_FAILED",
-    0x50: "VERIFY",
-    0x51: "VERIFY_COMPLETE",
-    0x52: "VERIFY_FAILED",
-    0x60: "ACTIVATE",
-    0x61: "ACTIVATE_INSTALL_COMPLETE",
-    0x62: "ACTIVATE_INSTALL_FAILED",
-    0x70: "ERROR"
+    0x00: "IDLE",				# Initial state of the FOTA Handler after the ECU startup procedure
+    0x10: "INIT",				# The FOTA Handler is initialized, and Dcm is set into the correct state (in Dcm FOTA session and security access has been granted) */
+	0x20: "WAIT",				# The FOTA Handler has successfully processed the last received data chunk, returned the Dcm callout function, and is waiting for the next data chunk */
+	0x21: "WAIT_DOWNLOAD_COMPLETED",	# The FOTA Handler has successfully processed the last received data chunk, returned the Dcm callout function, and is waiting for the next data chunk */
+	0x22: "WAIT_DOWNLOAD_FAILED",		# The FOTA Handler has successfully processed the last received data chunk, returned the Dcm callout function, and is waiting for the next data chunk */
+	0x30: "PROCESSING",					# The FOTA Handler is triggered by the Dcm callout since a new chunk has been received and is processed in the callout context */
+	0x31: "PROCESSING_TRANSFER_COMPLETE",	# The FOTA Handler is triggered by the Dcm callout since a new chunk has been received and is processed in the callout context */
+	0x32: "PROCESSING_TRANSFER_FAILED",		# The FOTA Handler is triggered by the Dcm callout since a new chunk has been received and is processed in the callout context */
+	0x40: "READY",							# All FOTA data chunks have been installed, activation procedure can be triggered */
+	0x50: "VERIFY",						# Optional and implementer specific step, since the FOTA Target does not specify any details on the verification process */
+	0x51: "VERIFY_COMPLETE",			# Optional and implementer specific step, since the FOTA Target does not specify any details on the verification process */
+	0x52: "VERIFY_FAILED",				# Optional and implementer specific step, since the FOTA Target does not specify any details on the verification process */
+	0x60: "ACTIVATE",					# FOTA installation has finished and received a respective service job from the FOTA Master that indicates the partition switch during the next boot process */
+	0x61: "ACTIVATE_INSTALL_COMPLETE",	# FOTA installation has finished and received a respective service job from the FOTA Master that indicates the partition switch during the next boot process */
+	0x62: "ACTIVATE_INSTALL_FAILED",	# FOTA installation has finished and received a respective service job from the FOTA Master that indicates the partition switch during the next boot process */
+	0xFF: "ERROR"						# Optional and implementer specific. Reserved state for e.g., implementer specific error handling, which is not (yet) covered by the FOTA Target */
 }
 
 
@@ -199,8 +199,7 @@ class Updates(Action):
         frame_response = self._passive_response(ROUTINE_CONTROL, "Error at install routine.")
         if frame_response.data[1] != 0x71:
             log_info_message(logger, "Update failed at install step.")
-        self.get_ota_update_state(api_target_id)
-        frame_response =self.passive_response(REQUEST_UPDATE_STATUS , "Error at verify data routine.")
+            return
         if frame_response.data[1] != 0x72:
             log_info_message(logger, "Failed request update ota status.")
             return
@@ -262,3 +261,15 @@ class Updates(Action):
                 return "INVALID_STATE_TIMEOUT"
 
             time.sleep(1)
+
+    def get_ota_status(self, ecu_id):
+        try:
+            # Convert the hex string (e.g., "0x10") to an integer
+            hex_value = int(ecu_id, 16)
+            self.request_update_status(hex_value)
+            frame_response = self._passive_response(REQUEST_UPDATE_STATUS, "Request OTA state failed.")
+
+            return self.get_ota_update_state(frame_response.data[2])
+        
+        except ValueError:
+            return ToJSON()._to_json(f"Request OTA state failed", 0)

--- a/rest_api/routes/api.py
+++ b/rest_api/routes/api.py
@@ -302,23 +302,17 @@ def write_timing():
     return jsonify(result)
 
 @api_bp.route('ota_status', methods=['POST'])
-@requires_auth
 def ota_status():
    
     data = request.get_json()
   
     # Parse the hex value from the JSON input
-    hex_value_str = data.get('hex_value')
+    ecu_id = data.get('ecu_id')
     
-    if hex_value_str is None:
+    if ecu_id is None:
         return jsonify({"error": "Missing hex_value"}), 400
 
-    # Convert the hex string (e.g., "0x10") to an integer
-    try:
-        hex_value = int(hex_value_str, 16)
-    except ValueError:
-        return jsonify({"error": "Invalid hex value format"}), 400
-
     updater = Updates()
-    response = updater.get_ota_update_state(hex_value)
+    response = updater.get_ota_status(ecu_id)
+
     return jsonify({"state": response})

--- a/rest_api/routes/api.py
+++ b/rest_api/routes/api.py
@@ -300,3 +300,25 @@ def write_timing():
     result = writer._write_timing_info(id, timing_values)
 
     return jsonify(result)
+
+@api_bp.route('ota_status', methods=['POST'])
+@requires_auth
+def ota_status():
+   
+    data = request.get_json()
+  
+    # Parse the hex value from the JSON input
+    hex_value_str = data.get('hex_value')
+    
+    if hex_value_str is None:
+        return jsonify({"error": "Missing hex_value"}), 400
+
+    # Convert the hex string (e.g., "0x10") to an integer
+    try:
+        hex_value = int(hex_value_str, 16)
+    except ValueError:
+        return jsonify({"error": "Invalid hex value format"}), 400
+
+    updater = Updates()
+    response = updater.get_ota_update_state(hex_value)
+    return jsonify({"state": response})

--- a/rest_api/tests/mocking_tests_reads.py
+++ b/rest_api/tests/mocking_tests_reads.py
@@ -1,0 +1,406 @@
+import os
+import sys
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),'..',))
+sys.path.append(PROJECT_ROOT)
+import unittest
+from unittest.mock import *
+from unittest import TestCase, main
+from flask import Flask
+from flask import request, jsonify, Blueprint 
+from routes.api import api_bp
+from datetime import datetime
+import HtmlTestRunner
+import time
+import json
+
+class TestAPIReads(TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={
+        "battery_level": 80,
+        "voltage": 10,
+        "percentage": 2,
+        "battery_state_of_charge": "Fully charged",
+        "time_stamp": "2024-10-31T12:34:56.789123"
+        }
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=false")
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["battery_level"], fake_json["battery_level"], "The battery_level is incorrect")
+        self.assertEqual(response.json["voltage"], fake_json["voltage"],"The voltage is not correct")
+        self.assertEqual(response.json["percentage"], fake_json["percentage"],"The percentage is not correct")
+        self.assertEqual(response.json["battery_state_of_charge"], fake_json["battery_state_of_charge"],"The battery_state_of_charge is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery2(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+          "the values 'true' or 'false'"}
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=")
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The battery_level is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery3(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={'error': "The 'is_manual_flow' flag must be either 'true' or 'false'. You "
+           "provided: 'ds'"}
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=ds")
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The battery_level is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery4(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={
+        "battery_level": 80,
+        "voltage": 10,
+        "percentage": 2,
+        "battery_state_of_charge": "Fully charged",
+        "time_stamp": "2024-10-31T12:34:56.789123"
+        }
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=true")
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["battery_level"], fake_json["battery_level"], "The battery_level is incorrect")
+        self.assertEqual(response.json["voltage"], fake_json["voltage"],"The voltage is not correct")
+        self.assertEqual(response.json["percentage"], fake_json["percentage"],"The percentage is not correct")
+        self.assertEqual(response.json["battery_state_of_charge"], fake_json["battery_state_of_charge"],"The battery_state_of_charge is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery5(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={'error': "Invalid parameter 'battery_leve'. Use /get_identifiers to see valid "
+           'parameters.'}
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=false&item=battery_leve")
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The battery_level is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_battery6(self,mock_read_to_battery):
+
+        mock_read_to_battery.return_value={'battery_level': 80, 'time_stamp': '2024-11-12T11:07:13.146058'}
+        fake_json= mock_read_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get("/read_info_battery?is_manual_flow=false&item=battery_level")
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json['battery_level'], fake_json['battery_level'], "The battery_level is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={
+        "door": "Closed",
+        "passenger": "Unlocked",
+        "passenger_lock": "Unlocked",
+        "ajar": "No warning",
+        "time_stamp": "2024-10-31T12:34:56.789123"
+        }
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=false')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["door"], fake_json["door"], "The door status is incorrect")
+        self.assertEqual(response.json["passenger"], fake_json["passenger"],"The passenger is not correct")
+        self.assertEqual(response.json["passenger_lock"], fake_json["passenger_lock"],"The passenger_lock is not correct")
+        self.assertEqual(response.json["ajar"], fake_json["ajar"],"The ajar is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors2(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+          "the values 'true' or 'false'"}
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json)
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors3(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={'error': "The 'is_manual_flow' flag must be either 'true' or 'false'. You "
+           "provided: 'ds'"}
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=ds')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json)
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors4(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={
+            "door": "Closed",
+            "passenger": "Unlocked",
+            "passenger_lock": "Unlocked",
+            "ajar": "No warning",
+            "time_stamp": "2024-10-31T12:34:56.789123"
+        }
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=true')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        # self.assertEqual(response.json, fake_json, "The door status is incorrect")
+        self.assertEqual(response.json["door"], fake_json["door"], "The door status is incorrect")
+        self.assertEqual(response.json["passenger"], fake_json["passenger"],"The passenger is not correct")
+        self.assertEqual(response.json["passenger_lock"], fake_json["passenger_lock"],"The passenger_lock is not correct")
+        self.assertEqual(response.json["ajar"], fake_json["ajar"],"The ajar is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors5(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={'error': "Invalid parameter 'soor'. Use /get_identifiers to see valid "
+           'parameters.'}
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=true&item=soor')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The door status is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_doors6(self,mock_read_to_doors):
+
+        mock_read_to_doors.return_value={"door":"Closed","time_stamp":"2024-11-12T10:41:51.457556"}
+        fake_json= mock_read_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_doors?is_manual_flow=true&item=door')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["door"], fake_json["door"], "The door status is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine(self,mock_read_to_engine):
+        mock_read_to_engine.return_value={
+            "engine_load": 80,
+            "engine_rpm": 64,
+            "coolant_temperature": 95,
+            "fuel_level": 85,
+            "fuel_pressure": 50,
+            "intake_air_temperature": 25,
+            "oil_temperature": 70,
+            "throttle_position": 65,
+            "vehicle_speed": 120,
+            "time_stamp": "2024-10-31T12:34:56.789123"
+            }
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_engine?is_manual_flow=false')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["engine_rpm"], fake_json["engine_rpm"], "The engine_rpm is incorrect")
+        self.assertEqual(response.json["coolant_temperature"], fake_json["coolant_temperature"],"The voltage is not correct")
+        self.assertEqual(response.json["fuel_level"], fake_json["fuel_level"],"The percentage is not correct")
+        self.assertEqual(response.json["engine_load"], fake_json["engine_load"], "The engine_load is incorrect")
+        self.assertEqual(response.json["fuel_pressure"], fake_json["fuel_pressure"],"The fuel_pressure is not correct")
+        self.assertEqual(response.json["intake_air_temperature"], fake_json["intake_air_temperature"],"The intake_air_temperature is not correct")
+        self.assertEqual(response.json["throttle_position"], fake_json["throttle_position"], "The engine_rpm is incorrect")
+        self.assertEqual(response.json["oil_temperature"], fake_json["oil_temperature"],"The oil_temperature is not correct")
+        self.assertEqual(response.json["vehicle_speed"], fake_json["vehicle_speed"],"The speed is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine2(self,mock_read_to_engine):
+        mock_read_to_engine.return_value= {'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+          "the values 'true' or 'false'"}
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_engine?is_manual_flow=')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine3(self,mock_read_to_engine):
+        mock_read_to_engine.return_value= {'error': "The 'is_manual_flow' flag must be either 'true' or 'false'. You "
+           "provided: 'ds'"}
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_engine?is_manual_flow=ds')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine4(self,mock_read_to_engine):
+        mock_read_to_engine.return_value={'message': 'ssue encountered during Read by ID',
+            'negative_response': {'error_message': 'Security Access Denied',
+                                    'nrc': '0x33',
+                                'service_description': 'Read by ID',
+                                    'service_id': '0x22'}}
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.get('/read_info_engine?is_manual_flow=true')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        # self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+        self.assertEqual(response.json["engine_rpm"], fake_json["engine_rpm"], "The engine_rpm is incorrect")
+        self.assertEqual(response.json["coolant_temperature"], fake_json["coolant_temperature"],"The voltage is not correct")
+        self.assertEqual(response.json["fuel_level"], fake_json["fuel_level"],"The percentage is not correct")
+        self.assertEqual(response.json["engine_load"], fake_json["engine_load"], "The engine_load is incorrect")
+        self.assertEqual(response.json["fuel_pressure"], fake_json["fuel_pressure"],"The fuel_pressure is not correct")
+        self.assertEqual(response.json["intake_air_temperature"], fake_json["intake_air_temperature"],"The intake_air_temperature is not correct")
+        self.assertEqual(response.json["throttle_position"], fake_json["throttle_position"], "The engine_rpm is incorrect")
+        self.assertEqual(response.json["oil_temperature"], fake_json["oil_temperature"],"The oil_temperature is not correct")
+        self.assertEqual(response.json["vehicle_speed"], fake_json["vehicle_speed"],"The speed is not correct")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine5(self,mock_read_to_engine):
+        mock_read_to_engine.return_value={'error': "Invalid parameter 'engine_rpn'. Use /get_identifiers to see valid "
+           'parameters.'}
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.get('/read_info_engine?is_manual_flow=true&item=engine_rpn')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_engine6(self,mock_read_to_engine):
+        mock_read_to_engine.return_value={'engine_rpm': 64, 'time_stamp': '2024-11-12T10:55:37.346299'}
+        fake_json= mock_read_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.get('/read_info_engine?is_manual_flow=true&item=engine_rpm')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["engine_rpm"], fake_json["engine_rpm"], "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac(self,test_read_info_hvac):
+        test_read_info_hvac.return_value= {'ambient_air_temperature': 50,
+          'cabin_temperature': 20,
+          'cabin_temperature_driver_set': 21,
+          'fan_speed': 10,
+          'hvac_modes': {'AC Status': True,
+                         'Air Recirculation': False,
+                         'Defrost': False,
+                         'Front': True,
+                         'Legs': False},
+          'mass_air_flow': 5,
+          'time_stamp': '2024-11-05T16:05:36.240350'}
+        fake_json= test_read_info_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=false')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json['ambient_air_temperature'], fake_json['ambient_air_temperature'], "The data are incorrect")
+        self.assertEqual(response.json['cabin_temperature'], fake_json['cabin_temperature'], "The data are incorrect")
+        self.assertEqual(response.json['cabin_temperature_driver_set'], fake_json['cabin_temperature_driver_set'], "The data are incorrect")
+        self.assertEqual(response.json['fan_speed'], fake_json['fan_speed'], "The data are incorrect")
+        self.assertEqual(response.json['mass_air_flow'], fake_json['mass_air_flow'], "The data are incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac2(self,mock_read_to_hvac):
+        mock_read_to_hvac.return_value= {'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+          "the values 'true' or 'false'"}
+        fake_json= mock_read_to_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac3(self,mock_read_to_hvac):
+        mock_read_to_hvac.return_value= {'error': "The 'is_manual_flow' flag must be either 'true' or 'false'. You "
+           "provided: 'ds'"}
+        fake_json= mock_read_to_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=ds')
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The engine_rpm is incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac4(self,mock_read_info_hvac):
+        mock_read_info_hvac.return_value= {'ambient_air_temperature': 50,
+          'cabin_temperature': 20,
+          'cabin_temperature_driver_set': 21,
+          'fan_speed': 10,
+          'hvac_modes': {'AC Status': True,
+                         'Air Recirculation': False,
+                         'Defrost': False,
+                         'Front': True,
+                         'Legs': False},
+          'mass_air_flow': 5,
+          'time_stamp': '2024-11-05T16:05:36.240350'}
+        fake_json= mock_read_info_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=true')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json['ambient_air_temperature'], fake_json['ambient_air_temperature'], "The data are incorrect")
+        self.assertEqual(response.json['cabin_temperature'], fake_json['cabin_temperature'], "The data are incorrect")
+        self.assertEqual(response.json['cabin_temperature_driver_set'], fake_json['cabin_temperature_driver_set'], "The data are incorrect")
+        self.assertEqual(response.json['fan_speed'], fake_json['fan_speed'], "The data are incorrect")
+        self.assertEqual(response.json['mass_air_flow'], fake_json['mass_air_flow'], "The data are incorrect")
+
+  
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac5(self,mock_read_info_hvac):
+        mock_read_info_hvac.return_value= {'error': "Invalid parameter 'cabin_temperatu'. Use /get_identifiers to see valid "
+           'parameters.'}
+        fake_json= mock_read_info_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=true&item=cabin_temperatu')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The data are incorrect")
+
+    @patch('actions.read_info_action.ReadInfo')
+    def test_read_info_hvac6(self,mock_read_info_hvac):
+        mock_read_info_hvac.return_value= {"cabin_temperature":19,"time_stamp":"2024-11-12T10:38:52.189470"}
+        fake_json= mock_read_info_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.get('/read_info_hvac?is_manual_flow=true&item=cabin_temperature')
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json['cabin_temperature'], fake_json['cabin_temperature'], "The data are incorrect")
+ 
+
+    @patch('actions.access_timing_action.ReadAccessTiming')
+    def test_read_access_timing(self,mock_read_access_timing):
+        payload={
+        "p2_max": 100,
+        "p2_star_max": 200
+        }
+        mock_read_access_timing.return_value={'message': 'Timing parameters accessed successfully',
+            'timing_values': {'P2_MAX_TIME_DEFAULT': '100 seconds',
+            'P2_STAR_MAX_TIME_DEFAULT': '200 milliseconds'}}
+        fake_json= mock_read_access_timing.return_value
+        response = self.client.post('/read_access_timing',json={"sub_funct": 1})
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The door status is incorrect")
+
+    @patch('actions.access_timing_action.ReadAccessTiming')
+    def test_read_access_timing2(self,mock_read_access_timing):
+        mock_read_access_timing.return_value={'message': 'Timing parameters accessed successfully',
+  'timing_values': {'p2_max_time': '100 seconds',
+                    'p2_star_max_time': '200 milliseconds'}}
+        fake_json= mock_read_access_timing.return_value
+        response = self.client.post('/read_access_timing',json={"sub_funct": 3})
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The door status is incorrect")
+
+    @patch('actions.access_timing_action.ReadAccessTiming')
+    def test_read_access_timing3(self,mock_read_access_timing):
+        mock_read_access_timing.return_value={'message': 'Unexpected or insufficient response length while reading timing ''parameters',
+  'status': 'error'}
+        fake_json= mock_read_access_timing.return_value
+        response = self.client.post('/read_access_timing',json={"sub_funct": 2})
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The door status is incorrect")
+
+    @patch('actions.access_timing_action.ReadAccessTiming')
+    def test_read_access_timing4(self,mock_read_access_timing):
+        mock_read_access_timing.return_value={'message': "Missing 'sub_funct' parameter", 'status': 'error'}
+        fake_json= mock_read_access_timing.return_value
+        response = self.client.post('/read_access_timing',json={"sub_funct":None})
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The door status is incorrect")
+        
+
+if __name__ == '__main__':
+    runner = HtmlTestRunner.HTMLTestRunner(output="test_report")
+    unittest.main(testRunner=runner)

--- a/rest_api/tests/mocking_tests_writes.py
+++ b/rest_api/tests/mocking_tests_writes.py
@@ -1,0 +1,583 @@
+import os
+import sys
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),'..',))
+sys.path.append(PROJECT_ROOT)
+import unittest
+from unittest.mock import *
+from unittest import TestCase, main
+from flask import Flask
+from flask import request, jsonify, Blueprint 
+from routes.api import api_bp
+from datetime import datetime
+import HtmlTestRunner
+import time
+import json
+
+class BatteryInfoTestSuite(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_battery(self,mock_write_to_battery):
+        payload={
+            "is_manual_flow": "false",
+            "battery_level": 75,
+            "voltage": 10,
+            "battery_state_of_charge": 2,
+            "percentage": 2
+        }
+        mock_write_to_battery.return_value={
+            "message": "Successfully written values to Battery ECU.",
+            "written_values": {
+                "battery_level": 75,
+                "voltage": 10,
+                "percentage": 2
+            },
+            "time_stamp": "2024-10-31T12:34:56.789123"
+        }
+        fake_json= mock_write_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_battery', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    #When battery level is out of range 1-100
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_battery2(self,mock_write_to_battery):
+        payload={
+            "is_manual_flow": "false",
+            "battery_level": "Psasa",
+            "voltage": "Psasa",
+            "battery_state_of_charge": "Psasa",
+            "percentage": "Psasa"
+        }
+        mock_write_to_battery.return_value={
+            "message": "Successfully written values to Battery ECU.",
+            "written_values": {
+            }
+        }
+        fake_json= mock_write_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_battery', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_battery3(self,mock_write_to_battery):
+        payload={
+        }
+        mock_write_to_battery.return_value={'error': "The 'is_manual_flow' flag is required but was not provided in the "
+           'request.'}
+        fake_json= mock_write_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_battery', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json, "The json is not the expected one")
+       
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_battery4(self,mock_write_to_battery):
+        payload={
+            "is_manual_flow": "",
+            "battery_level": 75,
+            "voltage": 10,
+            "battery_state_of_charge": 2,
+            "percentage": 2
+        }
+        mock_write_to_battery.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+           "the values 'true' or 'false'"}
+        fake_json= mock_write_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_battery', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_battery5(self,mock_write_to_battery):
+        payload={
+            "is_manual_flow": "true",
+            "battery_level": 75,
+            "voltage": 10,
+            "battery_state_of_charge": 2,
+            "percentage": 2
+        }
+
+
+        mock_write_to_battery.return_value={
+            'message': 'Issue encountered during Write by ID',
+            'negative_response': {'error_message': 'Security Access Denied',
+            'nrc': '0x33',
+            'service_description': 'Write Data by Identifier',
+            'service_id': '0x2e'}}
+        fake_json= mock_write_to_battery.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.post('/write_info_battery', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+        
+class EngineInfoTestSuite(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_engine(self,mock_write_to_engine):
+        payload={
+        "is_manual_flow": "false",
+        "engine_rpm": 4000,
+        "coolant_temperature": 95,
+        "throttle_position": 65,
+        "vehicle_speed": 120,
+        "engine_load": 80,
+        "fuel_level": 85,
+        "oil_temperature": 70,
+        "fuel_pressure": 50,
+        "intake_air_temperature": 25,
+        "transmission_status": 3
+    }
+        self.maxDiff=None
+        mock_write_to_engine.return_value={
+        "message": "Successfully written values to Engine ECU.",
+        "written_values": {
+            "coolant_temperature": 95,
+            "throttle_position": 65,
+            "vehicle_speed": 120,
+            "engine_load": 80,
+            "fuel_level": 85,
+            "oil_temperature": 70,
+            "fuel_pressure": 50,
+            "intake_air_temperature": 25
+        },
+        "time_stamp": "2024-10-31T12:34:56.789123"
+    }
+
+        fake_json= mock_write_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_engine', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_engine2(self,mock_write_to_engine):
+        payload={
+        "is_manual_flow": "false",
+        "engine_rpm": "Psasa",
+        "coolant_temperature": "Psasa",
+        "throttle_position": "Psasa",
+        "vehicle_speed": "Psasa",
+        "engine_load": "Psasa",
+        "fuel_level": "Psasa",
+        "oil_temperature": "Psasa",
+        "fuel_pressure": "Psasa",
+        "intake_air_temperature": "Psasa",
+        "transmission_status": "Psasa"
+    }
+        self.maxDiff=None
+        mock_write_to_engine.return_value={
+        "message": "Successfully written values to Engine ECU.",
+        "written_values": {
+
+        }
+    }
+
+        fake_json= mock_write_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_engine', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_engine3(self,mock_write_to_engine):
+        payload={
+    }
+        mock_write_to_engine.return_value={'error': "The 'is_manual_flow' flag is required but was not provided in the "
+           'request.'}
+
+        fake_json= mock_write_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_engine', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_engine4(self,mock_write_to_engine):
+        payload={
+        "is_manual_flow": "",
+        "engine_rpm": 4000,
+        "coolant_temperature": 95,
+        "throttle_position": 65,
+        "vehicle_speed": 120,
+        "engine_load": 80,
+        "fuel_level": 85,
+        "oil_temperature": 70,
+        "fuel_pressure": 50,
+        "intake_air_temperature": 25,
+        "transmission_status": 3
+    }
+        self.maxDiff=None
+        mock_write_to_engine.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+           "the values 'true' or 'false'"}
+        fake_json= mock_write_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 2 })
+        response = self.client.post('/write_info_engine', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+    
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_engine5(self,mock_write_to_engine):
+        payload={
+        "is_manual_flow": "true",
+        "engine_rpm": 4000,
+        "coolant_temperature": 95,
+        "throttle_position": 65,
+        "vehicle_speed": 120,
+        "engine_load": 80,
+        "fuel_level": 85,
+        "oil_temperature": 70,
+        "fuel_pressure": 50,
+        "intake_air_temperature": 25,
+        "transmission_status": 3
+    }
+        self.maxDiff=None
+        mock_write_to_engine.return_value={
+            'message': 'Issue encountered during Write by ID',
+            'negative_response': {'error_message': 'Security Access Denied',
+            'nrc': '0x33',
+            'service_description': 'Write Data by Identifier',
+            'service_id': '0x2e'}}
+    
+
+        fake_json= mock_write_to_engine.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.post('/write_info_engine', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+class DoorsInfoTestSuite(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_doors(self,mock_write_to_doors):
+        payload={
+            "is_manual_flow": "false",
+            "door": 0,
+            "passenger": 0,
+            "driver": 1,
+            "passenger_lock": 0,
+            "ajar": 0
+        }
+        
+        mock_write_to_doors.return_value={
+        "message": "Successfully written values to Doors ECU.",
+        "written_values": {
+            "door": 0,
+            "passenger": 0,
+            "driver": 1,
+            "passenger_lock": 0,
+            "ajar": 0
+        },
+        "time_stamp": "2024-10-31T12:34:56.789123"
+    }
+        fake_json= mock_write_to_doors.return_value
+        response = self.client.post('/write_info_doors', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_doors2(self,mock_write_to_doors):
+        payload={
+            "is_manual_flow": "false",
+            "door": "dsa",
+            "passenger": "dsa",
+            "driver": "dsa",
+            "passenger_lock": "dsa",
+            "ajar": "dsa"
+        }
+        
+        mock_write_to_doors.return_value={
+        "message": "Successfully written values to Doors ECU.",
+        "written_values": {
+        }
+    }
+        fake_json= mock_write_to_doors.return_value
+        response = self.client.post('/write_info_doors', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_doors3(self,mock_write_to_doors):
+        payload={
+        }
+        
+        mock_write_to_doors.return_value={'error': "The 'is_manual_flow' flag is required but was not provided in the "
+           'request.'}
+        fake_json= mock_write_to_doors.return_value
+        response = self.client.post('/write_info_doors', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_doors4(self,mock_write_to_doors):
+        payload={
+            "is_manual_flow": "",
+            "door": 0,
+            "passenger": 0,
+            "driver": 1,
+            "passenger_lock": 0,
+            "ajar": 0
+        }
+        
+        mock_write_to_doors.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+           "the values 'true' or 'false'"}
+        fake_json= mock_write_to_doors.return_value
+        response = self.client.post('/write_info_doors', json=payload)
+        
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_doors5(self,mock_write_to_doors):
+        payload={
+            "is_manual_flow": "true",
+            "door": 0,
+            "passenger": 0,
+            "driver": 1,
+            "passenger_lock": 0,
+            "ajar": 0
+        }
+        
+        mock_write_to_doors.return_value={
+            'message': 'Issue encountered during Write by ID',
+            'negative_response': {'error_message': 'Security Access Denied',
+            'nrc': '0x33',
+            'service_description': 'Write Data by Identifier',
+            'service_id': '0x2e'}}
+        fake_json= mock_write_to_doors.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.post('/write_info_doors', json=payload)
+        
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+class HVACInfoTestSuite(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_hvac(self,mock_write_to_hvac):
+        payload={
+        "is_manual_flow": "false",
+        "mass_air_flow": 5,
+        "ambient_air_temperature": 5,
+        "cabin_temperature": 20,
+        "cabin_temperature_driver_set": 21,
+        "fan_speed": 10,
+        "hvac_modes": 5
+    }
+        
+        mock_write_to_hvac.return_value={
+        "message": "Successfully written values to HVAC ECU.",
+        "written_values": {
+            "mass_air_flow": 5,
+            "ambient_air_temperature": 5,
+            "cabin_temperature": 20,
+            "cabin_temperature_driver_set": 21,
+            "fan_speed": 10,
+            "hvac_modes": 5
+        },
+        "time_stamp": "2024-10-31T12:34:56.789123"
+    }
+        fake_json= mock_write_to_hvac.return_value
+        response = self.client.post('/write_info_hvac', json=payload)
+   
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_hvac2(self,mock_write_to_hvac):
+        payload={
+        "is_manual_flow": "false",
+        "mass_air_flow": "sdadas",
+        "ambient_air_temperature": "sdadas",
+        "cabin_temperature": "sdadas",
+        "cabin_temperature_driver_set": "sdadas",
+        "fan_speed": "sdadas",
+        "hvac_modes": "sdadas"
+    }
+        
+        mock_write_to_hvac.return_value={
+        "message": "Successfully written values to HVAC ECU.",
+        "written_values": {
+
+        }
+        }
+        fake_json= mock_write_to_hvac.return_value
+        response = self.client.post('/write_info_hvac', json=payload)
+   
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_hvac3(self,mock_write_to_hvac):
+        payload={
+        }
+        
+        mock_write_to_hvac.return_value={'error': "The 'is_manual_flow' flag is required but was not provided in the "
+           'request.'}
+        fake_json= mock_write_to_hvac.return_value
+        response = self.client.post('/write_info_hvac', json=payload)
+   
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_hvac4(self,mock_write_to_hvac):
+        payload={
+        "is_manual_flow": "",
+        "mass_air_flow": 5,
+        "ambient_air_temperature": 5,
+        "cabin_temperature": 20,
+        "cabin_temperature_driver_set": 21,
+        "fan_speed": 10,
+        "hvac_modes": 5
+    }
+        
+        mock_write_to_hvac.return_value={'error': "The 'is_manual_flow' flag cannot be an empty string. Please provide "
+           "the values 'true' or 'false'"}
+        fake_json= mock_write_to_hvac.return_value
+        response = self.client.post('/write_info_hvac', json=payload)
+   
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json, fake_json, "The message is incorrect")
+
+    @patch('actions.write_info_action.WriteInfo')
+    def test_write_info_hvac5(self,mock_write_to_hvac):
+        payload={
+        "is_manual_flow": "true",
+        "mass_air_flow": 5,
+        "ambient_air_temperature": 5,
+        "cabin_temperature": 20,
+        "cabin_temperature_driver_set": 21,
+        "fan_speed": 10,
+        "hvac_modes": 5
+    }
+        
+        mock_write_to_hvac.return_value={
+            'message': 'Issue encountered during Write by ID',
+            'negative_response': {'error_message': 'Security Access Denied',
+            'nrc': '0x33',
+            'service_description': 'Write Data by Identifier',
+            'service_id': '0x2e'}}
+        fake_json= mock_write_to_hvac.return_value
+        response = self.client.post('/change_session', json={ "sub_funct": 1 })
+        response = self.client.post('/write_info_hvac', json=payload)
+   
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json["message"], fake_json["message"], "The message is incorrect")
+        self.assertEqual(response.json["written_values"], fake_json["written_values"],"The written values aren't correct")
+
+class TimingInfoTestSuite(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(api_bp)
+        self.client = self.app.test_client()
+        self.app.testing=True
+
+    @patch('actions.access_timing_action.WriteAccessTiming')
+    def test_write_access_timing(self,mock_write_access_timing):
+
+        payload={
+        "p2_max": 50,
+        "p2_star_max": 100
+        }
+        mock_write_access_timing.return_value={
+        "message": "Timing parameters written successfully",
+        "written_values": {
+            "New P2 Max Time": 50,
+            "New P2 Star Max": 100
+            }
+        }
+        fake_json=mock_write_access_timing.return_value
+        response = self.client.post('/write_timing', json=payload)
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json, "The data are not correct")
+
+    @patch('actions.access_timing_action.WriteAccessTiming')
+    def test_write_access_timing2(self,mock_write_access_timing):
+
+        payload={
+        "p2_max": "50",
+        "p2_star_max": "100"
+        }
+        mock_write_access_timing.return_value={'message': "unsupported operand type(s) for >>: 'str' and 'int'"}
+        fake_json=mock_write_access_timing.return_value
+        response = self.client.post('/write_timing', json=payload)
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json, "The data are not correct")
+
+    @patch('actions.access_timing_action.WriteAccessTiming')
+    def test_write_access_timing3(self,mock_write_access_timing):
+
+        payload={
+
+        }
+        mock_write_access_timing.return_value={'message': 'Missing required parameters'}
+        fake_json=mock_write_access_timing.return_value
+        response = self.client.post('/write_timing', json=payload)
+        self.assertEqual(response.status_code,400, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json, "The data are not correct")
+
+    @patch('actions.access_timing_action.WriteAccessTiming')
+    def test_write_access_timing4(self,mock_write_access_timing):
+
+        payload={
+        "p2_max": 1.20,
+        "p2_star_max": 3.20
+        }
+        mock_write_access_timing.return_value={'message': "unsupported operand type(s) for >>: 'float' and 'int'"}
+        fake_json=mock_write_access_timing.return_value
+        response = self.client.post('/write_timing', json=payload)
+        self.assertEqual(response.status_code,200, "The HTTP response is not the expected one")
+        self.assertEqual(response.json,fake_json, "The data are not correct")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rest_api/utils/curls.txt
+++ b/rest_api/utils/curls.txt
@@ -119,3 +119,10 @@ curl -X POST http://localhost:5000/api/write_timing \
     "p2_max": 500,
     "p2_star_max": 1000
 }'
+
+23. /ota_status - POST Request
+
+curl -X POST http://localhost:5000/api/ota_status      
+ -H "Content-Type: application/json"      
+ -d '{"hex_value": "0x50", 
+ "is_manual_flow": false}'


### PR DESCRIPTION
## Description

API OTA STATUS UPDATE. POST API that execute a specific hex value relying on a specific dictionary
Mocking tests for API routes writes/reads. They are started but they are not finished yet.

## Trello link [[here](https://trello.com/c/iLuaj6T3/162-ota-status-endpoint)](put here the link)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
