### PR TITLE
Read&Write Access Timing Parameters endpoint improve

### DIFF
--- a/mcu/src/ReceiveFrames.cpp
+++ b/mcu/src/ReceiveFrames.cpp
@@ -288,7 +288,7 @@ bool ReceiveFrames::receiveFramesFromAPI()
             {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
-                if (elapsed.count() > timer_value / 20.0)
+                if (elapsed.count() > timer_value / 1000.0)
                 { 
                     stopTimer(sid);
                 }

--- a/rest_api/actions/generate_frames.py
+++ b/rest_api/actions/generate_frames.py
@@ -144,14 +144,20 @@ class GenerateFrame(CanBridge):
         data = [2, 0x83, sub_function] if response is False else [2, 0xC3, sub_function]
         self.send(id, data)
 
-    def write_timming_parameters(self, id, sub_function, new_p2_max_time, new_p2_star_max_time, response=False):
-        new_p2_max_time_bytes = [(new_p2_max_time >> 8) & 0xFF, new_p2_max_time & 0xFF]
-        new_p2_star_max_time_bytes = [(new_p2_star_max_time >> 8) & 0xFF, new_p2_star_max_time & 0xFF]
-
-        if not response:
-            data = [6, 0x83, sub_function] + new_p2_max_time_bytes + new_p2_star_max_time_bytes
+    def write_timming_parameters(self, id, sub_function, new_p2_max_time=0, new_p2_star_max_time=0, response=False):
+        if sub_function == 2:
+            if not response:
+                data = [3, 0x83, sub_function]
+            else:
+                data = [3, 0xC3, sub_function]
         else:
-            data = [6, 0xC3, sub_function] + new_p2_max_time_bytes + new_p2_star_max_time_bytes
+            new_p2_max_time_bytes = [(new_p2_max_time >> 8) & 0xFF, new_p2_max_time & 0xFF]
+            new_p2_star_max_time_bytes = [(new_p2_star_max_time >> 8) & 0xFF, new_p2_star_max_time & 0xFF]
+
+            if not response:
+                data = [6, 0x83, sub_function] + new_p2_max_time_bytes + new_p2_star_max_time_bytes
+            else:
+                data = [6, 0xC3, sub_function] + new_p2_max_time_bytes + new_p2_star_max_time_bytes
 
         self.send(id, data)
 

--- a/rest_api/routes/api.py
+++ b/rest_api/routes/api.py
@@ -280,13 +280,43 @@ def get_data_identifiers():
 
 @api_bp.route('/read_access_timing', methods=['POST'])
 def access_timing():
-    data = request.get_json()
-    sub_funct = data.get('sub_funct')
-    if sub_funct is None:
-        return jsonify({"status": "error", "message": "Missing 'sub_funct' parameter"}), 400
-    requester = ReadAccessTiming()
-    response = requester._read_timing_info(id, sub_funct)
-    return jsonify(response)
+    try:
+        data = request.get_json()
+        errors = []
+        log_info_message(logger, f"Read Access Timing Parameters Request received: {data}")
+
+        sub_funct = int(data.get('sub_funct'))
+        if sub_funct is None:
+            errors.append({"status": "error", "message": "Missing 'sub_funct' parameter"})
+
+        ecu_id_str = data.get('ecu_id')
+        try:
+            ecu_id = int(ecu_id_str, 16)
+        except ValueError:
+            errors.append({"error": "Invalid ecu", "details": f"Ecu {ecu_id_str} is not a valid hexadecimal value"})
+        
+        requester = RequestIdAction()
+        response_req_json = requester.read_ids()
+        log_info_message(logger, f" JSON CU ID: {response_req_json}")
+        ecu_values = response_req_json.get("ecus", [])
+        valid_values = [int(ecu["ecu_id"], 16) for ecu in ecu_values]
+        mcu_id = int(response_req_json.get("mcu_id"), 16)
+
+        if ecu_id not in valid_values and ecu_id != mcu_id:
+            errors.append({"error": "Invalid ecu", "details": f"Ecu {hex(ecu_id)} is not supported"})
+
+        if errors:
+            return jsonify({"errors": errors}), 400
+
+        requester = ReadAccessTiming()
+        response = requester._read_timing_info(ecu_id, sub_funct)
+        return jsonify(response)
+
+    except CustomError as e:
+        return jsonify(e.message), 400
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @api_bp.route('/reset_ecu', methods=['POST'])
@@ -301,20 +331,54 @@ def reset_module():
 
 @api_bp.route('/write_timing', methods=['POST'])
 def write_timing():
-    data = request.get_json()
+    try:
+        data = request.get_json()
+        errors = []
+        log_info_message(logger, f"Write Access Timing Parameters Request received: {data}")
 
-    if not data or 'p2_max' not in data or 'p2_star_max' not in data:
-        return jsonify({"message": "Missing required parameters"}), 400
+        sub_funct = int(data.get('sub_funct'))
+        if sub_funct is None:
+            error.append({"status": "error", "message": "Missing 'sub_funct' parameter"})
 
-    p2_max = data.get('p2_max')
-    p2_star_max = data.get('p2_star_max')
+        ecu_id_str = data.get('ecu_id')
+        try:
+            ecu_id = int(ecu_id_str, 16)
+        except ValueError:
+            errors.append({"error": "Invalid ecu", "details": f"Ecu {ecu_id_str} is not a valid hexadecimal value"})
+        
+        requester = RequestIdAction()
+        response_req_json = requester.read_ids()
+        ecu_values = response_req_json.get("ecus", [])
+        valid_values = [int(ecu["ecu_id"], 16) for ecu in ecu_values]
+        mcu_id = int(response_req_json.get("mcu_id"), 16)
 
-    timing_values = {
-        "p2_max": p2_max,
-        "p2_star_max": p2_star_max
-    }
+        if ecu_id not in valid_values and ecu_id != mcu_id:
+            errors.append({"error": "Invalid ecu", "details": f"Ecu {hex(ecu_id)} is not supported"})
 
-    writer = WriteAccessTiming()
-    result = writer._write_timing_info(id, timing_values)
+        writer = WriteAccessTiming()
+        if sub_funct == 2:
+            if errors:
+                return jsonify({"errors": errors}), 400
+            result = writer._write_timing_info(sub_funct, ecu_id)
+        else:
+            if not data or 'p2_max' not in data or 'p2_star_max' not in data:
+                errors.append({"message": "Missing required parameters"})
 
-    return jsonify(result)
+            if errors:
+                return jsonify({"errors": errors}), 400
+
+            p2_max = int(data.get('p2_max'))
+            p2_star_max = int(data.get('p2_star_max'))
+
+            timing_values = {
+                "p2_max": p2_max,
+                "p2_star_max": p2_star_max
+            }
+            result = writer._write_timing_info(sub_funct, ecu_id, timing_values)
+        return jsonify(result)
+
+    except CustomError as e:
+        return jsonify(e.message), 400
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/rest_api/routes/api.py
+++ b/rest_api/routes/api.py
@@ -213,10 +213,11 @@ def read_dtc_info():
 @api_bp.route('/clear_dtc_info', methods=['POST'])
 def clear_dtc_info():
     try:
+        data = request.get_json()
         errors = []
-        log_info_message(logger, f"Clear DTC Request received: {request.args}")
-
-        ecu_id_str = request.args.get('ecu_id', default='0x11')
+        log_info_message(logger, f"Clear DTC Request received: {data}")
+        
+        ecu_id_str = data.get('ecu_id')
         try:
             ecu_id = int(ecu_id_str, 16)
         except ValueError:
@@ -230,7 +231,7 @@ def clear_dtc_info():
         if ecu_id not in valid_values:
             errors.append({"error": "Invalid ecu", "details": f"Ecu {hex(ecu_id)} is not supported"})
 
-        dtc_group = request.args.get('dtc_group')
+        dtc_group = data.get('dtc_group')
         if errors:
             return jsonify({"errors": errors}), 400
 

--- a/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -7,8 +7,8 @@
 
 
 // Define static constants
-const uint16_t AccessTimingParameter::DEFAULT_P2_MAX_TIME = 40;
-const uint16_t AccessTimingParameter::DEFAULT_P2_STAR_MAX_TIME = 400;
+const uint16_t AccessTimingParameter::DEFAULT_P2_MAX_TIME = 2000;
+const uint16_t AccessTimingParameter::DEFAULT_P2_STAR_MAX_TIME = 20000;
 
 // Define static variables
 uint16_t AccessTimingParameter::p2_max_time = AccessTimingParameter::DEFAULT_P2_MAX_TIME;

--- a/utils/src/ReceiveFrames.cpp
+++ b/utils/src/ReceiveFrames.cpp
@@ -209,7 +209,7 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
             while (battery->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
-                if (elapsed.count() > timer_value / 20.0) {
+                if (elapsed.count() > timer_value / 1000.0) {
                     stopTimer(frame_dest_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));


### PR DESCRIPTION
-Updated the read and write endpoints to accept the ECU ID in the JSON payload for specifying the target ECU for operations. Added the sub_function parameter to the write endpoint to indicate whether to perform a reset or write on access timing parameters. 
-Modified the backend logic so that the accessTimingParameters values are stored in milliseconds.

## Trello link [here](https://trello.com/c/qqbf5UL2/166-create-endpoint-for-write-accesstimingparameter)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
