### PR TITLE
ClearDTC json return modified and bug fixed.

### DIFF
--- a/rest_api/actions/dtc_info.py
+++ b/rest_api/actions/dtc_info.py
@@ -114,14 +114,19 @@ class DiagnosticTroubleCode(Action):
             log_info_message(logger, "Clearing DTCs information with positive response")
             if dtc_group == "p":
                 dtc_group_code = 0x000aaa
+                dtc_group_str = "Powertrain"
             elif dtc_group == "c":
                 dtc_group_code = 0x010aaa
+                dtc_group_str = "Chassis"
             elif dtc_group == "b":
                 dtc_group_code = 0x020aaa
+                dtc_group_str = "Body"
             elif dtc_group == "u":
                 dtc_group_code = 0x030aaa
+                dtc_group_str = "Network"
             elif dtc_group == "a":
                 dtc_group_code = 0xffffff
+                dtc_group_str = "All"
             else:
                 dtc_group_code = 0x000000 # invalid dtc_group
 
@@ -129,8 +134,12 @@ class DiagnosticTroubleCode(Action):
             frame_response = self._passive_response(CLEAR_DTC, "Error clearing DTCs")
 
             if frame_response.data[1] == 0x54:
+                dtc_count_deleted = frame_response.data[2]
+      
                 json_response = {
-                    "message": f"Clearing DTCs information with positive response succeded"
+                    "message": "Clearing DTCs information with positive response succeeded",
+                    "category": dtc_group_str,
+                    "cleared_dtc_count": dtc_count_deleted
                 }
                 return jsonify(json_response), 200
 

--- a/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -204,18 +204,28 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
         {
             case 0x10:
                 MCU::mcu->stop_flags[sid] = false;
+                MCU::mcu->stop_flags.erase(sid);
+                MCU::mcu->active_timers[sid].wait();
                 break;
             case 0x11:
                 battery->_ecu->stop_flags[sid] = false;
+                battery->_ecu->stop_flags.erase(sid);
+                battery->_ecu->active_timers[sid].wait();
                 break;
             case 0x12:
                 engine->_ecu->stop_flags[sid] = false;
+                engine->_ecu->stop_flags.erase(sid);
+                engine->_ecu->active_timers[sid].wait();
                 break;
             case 0x13:
                 doors->_ecu->stop_flags[sid] = false;
+                doors->_ecu->stop_flags.erase(sid);
+                doors->_ecu->active_timers[sid].wait();
                 break;
             case 0x14:
                 hvac->_ecu->stop_flags[sid] = false;
+                hvac->_ecu->stop_flags.erase(sid);
+                hvac->_ecu->active_timers[sid].wait();
                 break;
             default:
                 break; 

--- a/uds/clear_dtc/src/ClearDtc.cpp
+++ b/uds/clear_dtc/src/ClearDtc.cpp
@@ -51,6 +51,8 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
 
     std::string line;
     std::vector<std::string> remaining_dtcs;
+    uint8_t dtc_count_match = 0;
+    uint8_t total_dtc_count = 0;
 
     while (std::getline(input_file, line))
     {
@@ -59,6 +61,11 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
         {
             remaining_dtcs.push_back(line);
         }
+        else
+        {
+            dtc_count_match++;
+        }
+        total_dtc_count++;
     }
 
     input_file.close();
@@ -81,10 +88,11 @@ void ClearDtc::clearDtc(int id, std::vector<uint8_t> data)
         /* Open the file for writing, clearing its contents */
         file_dtc.open(this->path_to_dtc, std::ios::out | std::ios::trunc);  
         file_dtc.close();
+        dtc_count_match = total_dtc_count;
     }
 
     LOG_INFO(logger.GET_LOGGER(), "DTCs cleared successfully");
-    this->generate->clearDiagnosticInformation(new_id, {}, true);
+    this->generate->clearDiagnosticInformation(new_id, {}, dtc_count_match, true);
     AccessTimingParameter::stopTimingFlag(lowerbits, 0x14);
 }
 

--- a/utils/include/GenerateFrames.h
+++ b/utils/include/GenerateFrames.h
@@ -272,7 +272,7 @@ class GenerateFrames
          * @param response variable for request or response frame
          Response&Request
          */
-        void clearDiagnosticInformation(int id, std::vector<uint8_t> group_of_dtc = {0xFF, 0xFF, 0xFF}, bool response=false);
+        void clearDiagnosticInformation(int id, std::vector<uint8_t> group_of_dtc = {0xFF, 0xFF, 0xFF}, uint8_t dtc_count_deleted = 0x00, bool response=false);
         /**
          * @brief Frame for Access timing parameters
          * 

--- a/utils/src/GenerateFrames.cpp
+++ b/utils/src/GenerateFrames.cpp
@@ -448,7 +448,7 @@ void GenerateFrames::GenerateConsecutiveFrames(int id, std::vector<uint8_t> data
     }
 }
 
-void GenerateFrames::clearDiagnosticInformation(int id, std::vector<uint8_t> group_of_dtc, bool response)
+void GenerateFrames::clearDiagnosticInformation(int id, std::vector<uint8_t> group_of_dtc, uint8_t dtc_count_deleted, bool response)
 {
     std::vector<uint8_t> data;
     /* Request */
@@ -473,7 +473,7 @@ void GenerateFrames::clearDiagnosticInformation(int id, std::vector<uint8_t> gro
         
     }
     /* Response */
-    data = {0x01, 0x54};
+    data = {0x02, 0x54, dtc_count_deleted};
     this->sendFrame(id, data);
     return;
 }

--- a/utils/src/ReceiveFrames.cpp
+++ b/utils/src/ReceiveFrames.cpp
@@ -226,7 +226,7 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
             while (engine->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
-                if (elapsed.count() > timer_value / 20.0) {
+                if (elapsed.count() > timer_value / 1000.0) {
                     stopTimer(frame_dest_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -243,7 +243,7 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
             while (doors->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
-                if (elapsed.count() > timer_value / 20.0) {
+                if (elapsed.count() > timer_value / 1000.0) {
                     stopTimer(frame_dest_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -260,7 +260,7 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
             while (hvac->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
-                if (elapsed.count() > timer_value / 20.0) {
+                if (elapsed.count() > timer_value / 1000.0) {
                     stopTimer(frame_dest_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));


### PR DESCRIPTION
-Updated the ClearDtc service in the backend to return the number of cleared DTCs when the result is positive. Included this information in the JSON sent from the API, along with the group used to filter the DTCs.
-Added logic to join the thread even in cases of a positive response.

## Trello updateClearDTC [here](https://trello.com/c/R0wOjUPz/167-clear-dtc-return-number-of-dtcs-deleted-backend-api)
## Trello bug [here](https://trello.com/c/yhDuzSsV/39-backendmoderate-requests-wait-for-the-starttimer-duration-to-pass)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
