### PR TITLE
state_of_charge replaced with battery_state_of_charge

### DIFF
--- a/rest_api/actions/read_info_action.py
+++ b/rest_api/actions/read_info_action.py
@@ -95,7 +95,7 @@ class ReadInfo(Action):
                     identifier = identifiers[item]
                     result_value = self._read_by_identifier(id, int(identifier, 16))
 
-                    if item == "state_of_charge" and result_value:
+                    if item == "battery_state_of_charge" and result_value:
                         result_value = self._get_battery_state_of_charge(result_value)
 
                     results[item] = result_value if result_value else "No data"
@@ -112,7 +112,7 @@ class ReadInfo(Action):
                 for key, identifier in identifiers.items():
                     result_value = self._read_by_identifier(id, int(identifier, 16))
 
-                    if key == "state_of_charge" and result_value:
+                    if key == "battery_state_of_charge" and result_value:
                         result_value = self._get_battery_state_of_charge(result_value)
 
                     results[key] = result_value if result_value else "No data"
@@ -121,7 +121,7 @@ class ReadInfo(Action):
                 "battery_level": self.hex_to_dec(results.get("battery_level")),
                 "voltage": self.hex_to_dec(results.get("voltage")),
                 "percentage": self.hex_to_dec(results.get("percentage")),
-                "battery_state_of_charge": results.get("state_of_charge"),
+                "battery_state_of_charge": results.get("battery_state_of_charge"),
                 # "life_cycle": self.hex_to_dec(results.get("life_cycle", "No data")),
                 # "fully_charged": self.hex_to_dec(results.get("fully_charged", "No data")),
                 # "serial_number": self.hex_to_dec(results.get("serial_number", "No data")),

--- a/rest_api/actions/write_info_action.py
+++ b/rest_api/actions/write_info_action.py
@@ -43,7 +43,7 @@ class WriteInfo(Action):
                 "battery_level": IDENTIFIER_BATTERY_ENERGY_LEVEL,
                 "voltage": IDENTIFIER_BATTERY_VOLTAGE,
                 "percentage": IDENTIFIER_BATTERY_PERCENTAGE,
-                "state_of_charge": IDENTIFIER_BATTERY_STATE_OF_CHARGE,
+                "battery_state_of_charge": IDENTIFIER_BATTERY_STATE_OF_CHARGE,
             }
 
             for key, value in data_dict.items():

--- a/rest_api/configs/data_identifiers.py
+++ b/rest_api/configs/data_identifiers.py
@@ -92,7 +92,7 @@ data_identifiers = {
             "battery_level": hex(IDENTIFIER_BATTERY_ENERGY_LEVEL),
             "voltage": hex(IDENTIFIER_BATTERY_VOLTAGE),
             "percentage": hex(IDENTIFIER_BATTERY_PERCENTAGE),
-            "state_of_charge": hex(IDENTIFIER_BATTERY_STATE_OF_CHARGE),
+            "battery_state_of_charge": hex(IDENTIFIER_BATTERY_STATE_OF_CHARGE),
             # "temperature": IDENTIFIER_BATTERY_TEMPERATURE,
             # "life_cycle": IDENTIFIER_BATTERY_LIFE_CYCLE,
             # "fully_charged": IDENTIFIER_BATTERY_FULLY_CHARGED,


### PR DESCRIPTION
-state_of_charge replaced with battery_state_of_charge in API

## Trello link [here](https://trello.com/c/zGZfYKFp/168-replace-stateofcharge-with-batterystateofcharge-in-api)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
