### PR TITLE
Bad response with 3100 bug fixed

### DIFF
--- a/mcu/include/ReceiveFrames.h
+++ b/mcu/include/ReceiveFrames.h
@@ -239,9 +239,9 @@ namespace MCU
     bool running;
 
     /* Method that start time processing frame. */
-    void startTimer(uint8_t sid);
+    void startTimer(uint8_t sid, uint8_t sender_id);
     /* Method that stop time processing frame. */
-    void stopTimer(uint8_t sid);
+    void stopTimer(uint8_t sid, uint8_t sender_id);
 
   protected:
     /* The socket from where we read the frames */

--- a/uds/access_timing_parameters/src/AccessTimingParameter.cpp
+++ b/uds/access_timing_parameters/src/AccessTimingParameter.cpp
@@ -211,6 +211,7 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
                 {
                     MCU::mcu->active_timers[sid].wait();
                 }
+                MCU::mcu->active_timers.erase(sid);
                 break;
             }
             case 0x11:
@@ -222,6 +223,7 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
                 {
                     battery->_ecu->active_timers[sid].wait();
                 }
+                battery->_ecu->active_timers.erase(sid);
                 break;
             }
             case 0x12:
@@ -233,6 +235,7 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
                 {
                     engine->_ecu->active_timers[sid].wait();
                 }
+                engine->_ecu->active_timers.erase(sid);
                 break;
             }
             case 0x13:
@@ -244,6 +247,7 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
                 {
                     doors->_ecu->active_timers[sid].wait();
                 }
+                doors->_ecu->active_timers.erase(sid);
                 break;
             }
             case 0x14:
@@ -255,6 +259,7 @@ void AccessTimingParameter::stopTimingFlag(uint8_t receiver_id, uint8_t sid)
                 {
                     hvac->_ecu->active_timers[sid].wait();
                 }
+                hvac->_ecu->active_timers.erase(sid);
                 break;
             }
             default:

--- a/utils/include/ReceiveFrames.h
+++ b/utils/include/ReceiveFrames.h
@@ -188,9 +188,9 @@ public:
     void receive(HandleFrames &handle_frame);
 
     /* Method that start time processing frame. */
-    void startTimer(uint8_t frame_dest_id, uint8_t sid);
+    void startTimer(uint8_t sender_id, uint8_t receiver_id, uint8_t sid);
     /* Method that stop time processing frame. */
-    void stopTimer(uint8_t frame_dest_id, uint8_t sid);
+    void stopTimer(uint8_t sender_id, uint8_t receiver_id, uint8_t sid);
 
     /**
      * @brief Stops the receive process gracefully.

--- a/utils/src/ReceiveFrames.cpp
+++ b/utils/src/ReceiveFrames.cpp
@@ -132,13 +132,14 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
         printFrame(frame);
 
         uint8_t frame_dest_id = frame.can_id & 0xFF;
+        uint8_t sender_id = (frame.can_id >> 8) & 0xFF;
 
         /* Starting frame processing timing if is it a frame request for MCU */
         auto it = std::find(service_sids.begin(), service_sids.end(), frame.data[1]);
 
         if (it != service_sids.end() && frame.data[1] != TRANSFER_DATA_SID)
         {
-            startTimer(frame_dest_id, frame.data[1]);
+            startTimer(sender_id, frame_dest_id, frame.data[1]);
         }
 
         if (((frame.can_id >> 8) & 0xFF) == 0) 
@@ -171,7 +172,7 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
             /* Create a vector of uint8_t (bytes) containing the data to be sent */
             std::vector<uint8_t> data = {0x01, 0xD9};
             
-            uint16_t id = (frame_dest_id << 8) | 0x10;
+            uint16_t id = (frame_dest_id << 8) | sender_id;
             frame.sendFrame(id, data);
             LOG_DEBUG(receive_logger.GET_LOGGER(), "Response sent to MCU");
 
@@ -184,7 +185,7 @@ void ReceiveFrames::bufferFrameOut(HandleFrames &handle_frame)
     }
 }
 
-void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
+void ReceiveFrames::startTimer(uint8_t sender_id, uint8_t receiver_id, uint8_t sid) {
     /* Define the correct timer value based on SID */
     uint16_t timer_value;
     if (sids_using_p2_max_time.find(sid) != sids_using_p2_max_time.end())
@@ -194,23 +195,26 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
         timer_value = AccessTimingParameter::p2_star_max_time;
     }
 
-    LOG_INFO(receive_logger.GET_LOGGER(), "Started frame processing timing for frame with SID {:x} with max_time = {} on ECU with id {}.", sid, timer_value, frame_dest_id);
+    LOG_INFO(receive_logger.GET_LOGGER(), "Started frame processing timing for frame with SID {:x} with max_time = {} on ECU with id {}.", sid, timer_value, sender_id);
 
     auto start_time = std::chrono::steady_clock::now();
-    switch(frame_dest_id)
+    switch(receiver_id)
     {
     case 0x11:
         battery->_ecu->timing_parameters[sid] = start_time.time_since_epoch().count();
 
         // Initialize stop flag for this SID
         battery->_ecu->stop_flags[sid] = true;
+        if (battery->_ecu->active_timers.find(sid) != battery->_ecu->active_timers.end()) {
+            battery->_ecu->active_timers.erase(sid);
+        }
 
-        battery->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, frame_dest_id]() {
+        battery->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, sender_id, receiver_id]() {
             while (battery->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
                 if (elapsed.count() > timer_value / 1000.0) {
-                    stopTimer(frame_dest_id, sid);
+                    stopTimer(sender_id, receiver_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
@@ -221,13 +225,16 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
 
         // Initialize stop flag for this SID
         engine->_ecu->stop_flags[sid] = true;
+        if (engine->_ecu->active_timers.find(sid) != engine->_ecu->active_timers.end()) {
+            engine->_ecu->active_timers.erase(sid);
+        }
 
-        engine->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, frame_dest_id]() {
+        engine->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, sender_id, receiver_id]() {
             while (engine->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
                 if (elapsed.count() > timer_value / 1000.0) {
-                    stopTimer(frame_dest_id, sid);
+                    stopTimer(sender_id, receiver_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
@@ -238,13 +245,15 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
 
         // Initialize stop flag for this SID
         doors->_ecu->stop_flags[sid] = true;
-
-        doors->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, frame_dest_id]() {
+        if (doors->_ecu->active_timers.find(sid) != doors->_ecu->active_timers.end()) {
+            doors->_ecu->active_timers.erase(sid);
+        }
+        doors->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, sender_id, receiver_id]() {
             while (doors->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
                 if (elapsed.count() > timer_value / 1000.0) {
-                    stopTimer(frame_dest_id, sid);
+                    stopTimer(sender_id, receiver_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
@@ -255,25 +264,28 @@ void ReceiveFrames::startTimer(uint8_t frame_dest_id, uint8_t sid) {
 
         // Initialize stop flag for this SID
         hvac->_ecu->stop_flags[sid] = true;
+        if (hvac->_ecu->active_timers.find(sid) != hvac->_ecu->active_timers.end()) {
+            hvac->_ecu->active_timers.erase(sid);
+        }
 
-        hvac->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, frame_dest_id]() {
+        hvac->_ecu->active_timers[sid] = std::async(std::launch::async, [sid, this, start_time, timer_value, sender_id, receiver_id]() {
             while (hvac->_ecu->stop_flags[sid]) {
                 auto now = std::chrono::steady_clock::now();
                 std::chrono::duration<double> elapsed = now - start_time;
                 if (elapsed.count() > timer_value / 1000.0) {
-                    stopTimer(frame_dest_id, sid);
+                    stopTimer(sender_id, receiver_id, sid);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
         });
         break;
     default:
-        LOG_INFO(receive_logger.GET_LOGGER(), "starTimer function called with an ecu id unknown {:x}.", frame_dest_id);
+        LOG_INFO(receive_logger.GET_LOGGER(), "starTimer function called with an ecu id unknown {:x}.", sender_id);
         break;
     }
 }
 
-void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
+void ReceiveFrames::stopTimer(uint8_t sender_id, uint8_t receiver_id, uint8_t sid) {
     LOG_INFO(receive_logger.GET_LOGGER(), "stopTimer function called for frame with SID {:x}.", sid);
     
     auto end_time = std::chrono::steady_clock::now();
@@ -281,7 +293,7 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
     std::chrono::time_point<std::chrono::steady_clock> start_time;
     std::chrono::duration<double> processing_time;
 
-    switch (frame_dest_id) {
+    switch (receiver_id) {
     case 0x11:
         start_time = std::chrono::steady_clock::time_point(
             std::chrono::duration_cast<std::chrono::steady_clock::duration>(
@@ -295,7 +307,7 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
         if (battery->_ecu->active_timers.find(sid) != battery->_ecu->active_timers.end()) {
             /* Set stop flag to false for this SID */
             if (battery->_ecu->stop_flags[sid]) {
-                int id = ((sid & 0xFF) << 8) | ((sid >> 8) & 0xFF);
+                int id = (0x11 << 8) | sender_id;
                 LOG_INFO(receive_logger.GET_LOGGER(), 
                          "Service with SID {:x} sent the response pending frame.", sid);
                 
@@ -304,7 +316,6 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
                 battery->_ecu->stop_flags[sid] = false;
             }
             battery->_ecu->stop_flags.erase(sid);
-            battery->_ecu->active_timers[sid].wait();
         }
         break;
     case 0x12:
@@ -320,7 +331,7 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
         if (engine->_ecu->active_timers.find(sid) != engine->_ecu->active_timers.end()) {
             /* Set stop flag to false for this SID */
             if (engine->_ecu->stop_flags[sid]) {
-                int id = ((sid & 0xFF) << 8) | ((sid >> 8) & 0xFF);
+                int id = (0x12 << 8) | sender_id;
                 LOG_INFO(receive_logger.GET_LOGGER(), 
                          "Service with SID {:x} sent the response pending frame.", sid);
                 
@@ -329,7 +340,6 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
                 engine->_ecu->stop_flags[sid] = false;
             }
             engine->_ecu->stop_flags.erase(sid);
-            engine->_ecu->active_timers[sid].wait();
         }
         break;
     case 0x13:
@@ -345,7 +355,7 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
         if (doors->_ecu->active_timers.find(sid) != doors->_ecu->active_timers.end()) {
             /* Set stop flag to false for this SID */
             if (doors->_ecu->stop_flags[sid]) {
-                int id = ((sid & 0xFF) << 8) | ((sid >> 8) & 0xFF);
+                int id = (0x13 << 8) | sender_id;
                 LOG_INFO(receive_logger.GET_LOGGER(), 
                          "Service with SID {:x} sent the response pending frame.", sid);
                 
@@ -354,7 +364,6 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
                 doors->_ecu->stop_flags[sid] = false;
             }
             doors->_ecu->stop_flags.erase(sid);
-            doors->_ecu->active_timers[sid].wait();
         }
         break;
     case 0x14:
@@ -370,7 +379,7 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
         if (hvac->_ecu->active_timers.find(sid) != hvac->_ecu->active_timers.end()) {
             /* Set stop flag to false for this SID */
             if (hvac->_ecu->stop_flags[sid]) {
-                int id = ((sid & 0xFF) << 8) | ((sid >> 8) & 0xFF);
+                int id = (0x14 << 8) | sender_id;
                 LOG_INFO(receive_logger.GET_LOGGER(), 
                          "Service with SID {:x} sent the response pending frame.", sid);
                 
@@ -379,11 +388,10 @@ void ReceiveFrames::stopTimer(uint8_t frame_dest_id, uint8_t sid) {
                 hvac->_ecu->stop_flags[sid] = false;
             }
             hvac->_ecu->stop_flags.erase(sid);
-            hvac->_ecu->active_timers[sid].wait();
         }
         break;
     default:
-        LOG_INFO(receive_logger.GET_LOGGER(), "stopTimer function called with an ecu id unknown {:x}.", frame_dest_id);
+        LOG_INFO(receive_logger.GET_LOGGER(), "stopTimer function called with an ecu id unknown {:x}.", sender_id);
         break;
     }
 }


### PR DESCRIPTION
- Correctly setting the Response-Pending frame ID.
- Fixed the bug where the process would hang after sending a Response-Pending frame.

## Trello link [here](https://trello.com/c/vCKKOuSI/40-backendminorbad-response-with-3100)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
