### PR TITLE
Feature/project path set at runtime

### DIFF
--- a/autoscripts/create_sd_card.sh
+++ b/autoscripts/create_sd_card.sh
@@ -136,14 +136,8 @@ if [ -f "$IMG_PATH" ]; then
     fi
   fi
 
-  # Use a specific loop /dev/loop20
-  LOOP_DEVICE="/dev/loop20"
-
-  # Detach the existing loop device if /dev/loop10 is already in use
-  if losetup | grep -q "$LOOP_DEVICE"; then
-    echo "Detaching existing $LOOP_DEVICE..."
-    sudo losetup -d "$LOOP_DEVICE"
-  fi
+  # Use a specific loop /dev/loop1000
+  LOOP_DEVICE="/dev/loop1000"
 
   # Attach the image file to the specified loop device
   sudo losetup "$LOOP_DEVICE" "$IMG_PATH"
@@ -160,8 +154,8 @@ else
   echo "Creating image..."
   sudo truncate -s +300M "$IMG_PATH"
 
-  # Use a specific loop /dev/loop20
-  LOOP_DEVICE="/dev/loop20"
+  # Use a specific loop /dev/loop1000
+  LOOP_DEVICE="/dev/loop1000"
 
   # Step 8: Create a loop device and attach it to the specified loop device
   sudo losetup "$LOOP_DEVICE" "$IMG_PATH"

--- a/autoscripts/create_sd_card.sh
+++ b/autoscripts/create_sd_card.sh
@@ -136,10 +136,23 @@ if [ -f "$IMG_PATH" ]; then
     fi
   fi
 
-  LOOP_DEVICE=$(losetup -fP --show "$IMG_PATH")
-   # Extract the loop number from LOOP_DEVICE
+  # Use a specific loop /dev/loop20
+  LOOP_DEVICE="/dev/loop20"
+
+  # Detach the existing loop device if /dev/loop10 is already in use
+  if losetup | grep -q "$LOOP_DEVICE"; then
+    echo "Detaching existing $LOOP_DEVICE..."
+    sudo losetup -d "$LOOP_DEVICE"
+  fi
+
+  # Attach the image file to the specified loop device
+  sudo losetup "$LOOP_DEVICE" "$IMG_PATH"
+  echo "Loop device set to: $LOOP_DEVICE"
+
+  # Extract the loop number from LOOP_DEVICE
   LOOP_NUMBER=$(basename "$LOOP_DEVICE" | grep -o '[0-9]*')
-  #Change permissions of the loop device
+
+  # Ensure the loop device has appropriate permissions
   sudo chmod 777 "$LOOP_DEVICE"
   
 else
@@ -147,9 +160,12 @@ else
   echo "Creating image..."
   sudo truncate -s +300M "$IMG_PATH"
 
-  # Step 8: Create a loop device
-  LOOP_DEVICE=$(losetup -fP --show "$IMG_PATH")
-  echo "Loop device created: $LOOP_DEVICE"
+  # Use a specific loop /dev/loop20
+  LOOP_DEVICE="/dev/loop20"
+
+  # Step 8: Create a loop device and attach it to the specified loop device
+  sudo losetup "$LOOP_DEVICE" "$IMG_PATH"
+  echo "Loop device created and attached to $LOOP_DEVICE"
 
   # Extract the loop number from LOOP_DEVICE
   LOOP_NUMBER=$(basename "$LOOP_DEVICE" | grep -o '[0-9]*')

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,0 +1,3 @@
+# Set your own project path like PROJECT_PATH=/home/nicu/Desktop/PoC_submodules/PoC/src
+[Paths]
+PROJECT_PATH=

--- a/ecu_simulation/BatteryModule/Makefile
+++ b/ecu_simulation/BatteryModule/Makefile
@@ -1,10 +1,8 @@
 ######### Makefile for BatteryModule
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-#POC Project root path
-PROJECT_PATH := $(shell cd $(shell pwd)/../../../ && pwd)
 SOFTWARE_VERSION = 0
-PROJECT_DEFINES = -DPROJECT_PATH=\"$(PROJECT_PATH)\" -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
+PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
@@ -88,7 +86,8 @@ UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
 			 $(OBJ_DIR)/ReceiveFrames.o \
 			 $(OBJ_DIR)/HandleFrames.o \
 			 $(OBJ_DIR)/FileManager.o \
-			 $(OBJ_DIR)/ECU.o
+			 $(OBJ_DIR)/ECU.o \
+			 $(OBJ_DIR)/Globals.o \
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -225,7 +224,8 @@ $(OBJ_DIR)/AccessTimingParameter.o: $(UDS_DIR)/access_timing_parameters/src/Acce
 $(OBJ_DIR)/NegativeResponse.o: $(UTILS_DIR)/NegativeResponse.cpp
 	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/NegativeResponse.cpp -o $(OBJ_DIR)/NegativeResponse.o
 
-
+$(OBJ_DIR)/Globals.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals.o
 #----------------------------------------------------Clean up--------------------------------------------------------
 .PHONY: clean
 clean:

--- a/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -7,6 +7,7 @@
 #include "BatteryModuleLogger.h"
 #include "FileManager.h"
 #include "RequestUpdateStatus.h"
+#include "Globals.h"
 
 Logger* batteryModuleLogger = nullptr;
 BatteryModule* battery = nullptr;

--- a/ecu_simulation/BatteryModule/src/main.cpp
+++ b/ecu_simulation/BatteryModule/src/main.cpp
@@ -3,8 +3,10 @@
 
 #include "BatteryModule.h"
 #include "BatteryModuleLogger.h"
+#include "Globals.h"
 
 int main() {
+    loadProjectPathForECU();
     #ifdef UNIT_TESTING_MODE
     batteryModuleLogger = new Logger;
     #else

--- a/ecu_simulation/BatteryModule/test/BatteryModuleTest.cpp
+++ b/ecu_simulation/BatteryModule/test/BatteryModuleTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "../include/BatteryModule.h"
+#include "Globals.h"
 
 bool containsLine(const std::string& output, const std::string& line)
 {

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -1,9 +1,8 @@
 ######### Makefile for DoorsModule
 
 #POC Project root path
-PROJECT_PATH := $(shell cd $(shell pwd)/../../../ && pwd)
 SOFTWARE_VERSION = 0
-PROJECT_DEFINES = -DPROJECT_PATH=\"$(PROJECT_PATH)\" -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
+PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
@@ -86,7 +85,8 @@ UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
 			 $(OBJ_DIR)/ReceiveFrames.o \
 			 $(OBJ_DIR)/HandleFrames.o \
 			 $(OBJ_DIR)/ECU.o \
-			 $(OBJ_DIR)/FileManager.o
+			 $(OBJ_DIR)/FileManager.o \
+			 $(OBJ_DIR)/Globals.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -223,6 +223,9 @@ $(OBJ_DIR)/ReadMemoryByAddress.o: $(UDS_DIR)/read_memory_by_address/src/ReadMemo
 
 $(OBJ_DIR)/FileManager.o: $(UTILS_DIR)/FileManager.cpp
 	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/FileManager.cpp -o $(OBJ_DIR)/FileManager.o
+
+$(OBJ_DIR)/Globals.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals.o
 
 .PHONY: clean
 clean:

--- a/ecu_simulation/DoorsModule/src/main.cpp
+++ b/ecu_simulation/DoorsModule/src/main.cpp
@@ -3,12 +3,14 @@
 
 #include "DoorsModule.h"
 #include "DoorsModuleLogger.h"
+#include "Globals.h"
 
 int main() {
+    loadProjectPathForECU();
     #ifdef UNIT_TESTING_MODE
     doorsModuleLogger = new Logger;
     #else
-    doorsModuleLogger = new Logger("doorsModuleLogger", "logs/doorsModuleLogger.log");
+    doorsModuleLogger = new Logger("doorsModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/DoorsModule/logs/doorsModuleLogger.log");
     #endif /* UNIT_TESTING_MODE */
     doors = new DoorsModule();
     std::thread receiveFrThread([]()

--- a/ecu_simulation/EngineModule/Makefile
+++ b/ecu_simulation/EngineModule/Makefile
@@ -1,9 +1,8 @@
 ######### Makefile for EngineModule
 
 #POC Project root path
-PROJECT_PATH := $(shell cd $(shell pwd)/../../../ && pwd)
 SOFTWARE_VERSION = 0
-PROJECT_DEFINES = -DPROJECT_PATH=\"$(PROJECT_PATH)\" -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
+PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
@@ -83,7 +82,8 @@ UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
 			 $(OBJ_DIR)/ReceiveFrames.o \
 			 $(OBJ_DIR)/HandleFrames.o \
 			 $(OBJ_DIR)/ECU.o \
-			 $(OBJ_DIR)/FileManager.o
+			 $(OBJ_DIR)/FileManager.o \
+			 $(OBJ_DIR)/Globals.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -222,6 +222,9 @@ $(OBJ_DIR)/ReadMemoryByAddress.o: $(UDS_DIR)/read_memory_by_address/src/ReadMemo
 
 $(OBJ_DIR)/FileManager.o: $(UTILS_DIR)/FileManager.cpp
 	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/FileManager.cpp -o $(OBJ_DIR)/FileManager.o
+
+$(OBJ_DIR)/Globals.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals.o
 #----------------------------------------------------Clean up--------------------------------------------------------
 
 .PHONY: clean

--- a/ecu_simulation/EngineModule/src/EngineModule.cpp
+++ b/ecu_simulation/EngineModule/src/EngineModule.cpp
@@ -7,6 +7,7 @@
 #include "EngineModuleLogger.h"
 #include "FileManager.h"
 #include "RequestUpdateStatus.h"
+#include "Globals.h"
 
 Logger* engineModuleLogger = nullptr;
 EngineModule* engine = nullptr;

--- a/ecu_simulation/EngineModule/src/main.cpp
+++ b/ecu_simulation/EngineModule/src/main.cpp
@@ -3,12 +3,14 @@
 
 #include "EngineModule.h"
 #include "EngineModuleLogger.h"
+#include "Globals.h"
 
 int main() {
+    loadProjectPathForECU();
     #ifdef UNIT_TESTING_MODE
     engineModuleLogger = new Logger;
     #else
-    engineModuleLogger = new Logger("engineModuleLogger", "logs/engineModuleLogger.log");
+    engineModuleLogger = new Logger("engineModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/logs/engineModuleLogger.log");
     #endif /* UNIT_TESTING_MODE */
     engine = new EngineModule();
     std::thread receiveFrThread([]()

--- a/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
+++ b/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "../include/EngineModule.h"
+#include "Globals.h"
 
 bool containsLine(const std::string& output, const std::string& line)
 {

--- a/ecu_simulation/HVACModule/Makefile
+++ b/ecu_simulation/HVACModule/Makefile
@@ -1,10 +1,8 @@
 ######### Makefile for HVACModule
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-#POC Project root path
-PROJECT_PATH := $(shell cd $(shell pwd)/../../../ && pwd)
 SOFTWARE_VERSION = 0
-PROJECT_DEFINES = -DPROJECT_PATH=\"$(PROJECT_PATH)\" -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
+PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
@@ -83,7 +81,8 @@ UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
 			 $(OBJ_DIR)/ReceiveFrames.o \
 			 $(OBJ_DIR)/HandleFrames.o \
 			 $(OBJ_DIR)/ECU.o \
-			 $(OBJ_DIR)/FileManager.o
+			 $(OBJ_DIR)/FileManager.o \
+			 $(OBJ_DIR)/Globals.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -220,6 +219,9 @@ $(OBJ_DIR)/ReadMemoryByAddress.o: $(UDS_DIR)/read_memory_by_address/src/ReadMemo
 
 $(OBJ_DIR)/FileManager.o: $(UTILS_DIR)/FileManager.cpp
 	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/FileManager.cpp -o $(OBJ_DIR)/FileManager.o
+
+$(OBJ_DIR)/Globals.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals.o
 
 .PHONY: clean
 clean:

--- a/ecu_simulation/HVACModule/src/main.cpp
+++ b/ecu_simulation/HVACModule/src/main.cpp
@@ -3,13 +3,15 @@
 
 #include "HVACModule.h"
 #include "HVACModuleLogger.h"
+#include "Globals.h"
 
 int main()
 {
+    loadProjectPathForECU();
     #ifdef UNIT_TESTING_MODE
     hvacModuleLogger = new Logger;
     #else
-    hvacModuleLogger = new Logger("hvacModuleLogger", "logs/hvacModuleLogger.log");
+    hvacModuleLogger = new Logger("hvacModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/HVACModule/logs/hvacModuleLogger.log");
     #endif
 
     hvac = new HVACModule();

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -1,11 +1,9 @@
 ######### Makefile for MCU module
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-#POC Project root path
-PROJECT_PATH := $(shell cd $(shell pwd)/../../ && pwd)
 SOFTWARE_VERSION = 0
 PYTHON_ENABLED = 1
-PROJECT_DEFINES = -DPROJECT_PATH=\"$(PROJECT_PATH)\" -DSOFTWARE_VERSION=${SOFTWARE_VERSION} -DPYTHON_ENABLED=${PYTHON_ENABLED}
+PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION} -DPYTHON_ENABLED=${PYTHON_ENABLED}
 
 #Python flags needed for pybing library
 PYTHON_INCL_DIR= -I/usr/include/python3.8
@@ -17,7 +15,7 @@ PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -l
 
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -g -Wall -Werror -pthread \
+CFLAGS = -std=c++17 -O3 -Wall -Werror -pthread \
          -I../include \
          -I./include \
          -I../utils/include \
@@ -94,7 +92,8 @@ UTILS_OBJS = $(OBJ_DIR)/MemoryManager.o \
 			 $(OBJ_DIR)/ECU_ReceiveFrames.o \
 			 $(OBJ_DIR)/HandleFrames.o \
 			 $(OBJ_DIR)/FileManager.o \
-			 $(OBJ_DIR)/ECU.o
+			 $(OBJ_DIR)/ECU.o \
+			 $(OBJ_DIR)/Globals.o
 
 # UDS object files
 UDS_OBJS = $(OBJ_DIR)/DiagnosticSessionControl.o \
@@ -232,6 +231,9 @@ $(OBJ_DIR)/AccessTimingParameter.o: $(UDS_DIR)/access_timing_parameters/src/Acce
   
 $(OBJ_DIR)/NegativeResponse.o: $(UTILS_DIR)/NegativeResponse.cpp
 	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/NegativeResponse.cpp -o $(OBJ_DIR)/NegativeResponse.o
+
+$(OBJ_DIR)/Globals.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals.o
 
 #----------------------------------------------------UNIT TESTS-----------------------------------------------------
 

--- a/mcu/src/MCUModule.cpp
+++ b/mcu/src/MCUModule.cpp
@@ -1,9 +1,13 @@
 #include <thread>
+#include <random>
+#include <sstream>
+#include <iomanip>
 
 #include "MCUModule.h"
 #include "MCULogger.h"
 #include "FileManager.h"
 #include "MemoryManager.h"
+#include "Globals.h"
 
 Logger* MCULogger = nullptr;
 namespace MCU

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -3,9 +3,11 @@
 
 #include "MCUModule.h"
 #include "MCULogger.h"
+#include "Globals.h"
 
 int main() {
 
+    loadProjectPathForMCU();
     #ifndef UNIT_TESTING_MODE
     MCULogger = new Logger("MCULogger", std::string(PROJECT_PATH) + "/backend/mcu/logs/MCULogs.log");
     #else

--- a/uds/clear_dtc/utest/ClearDtcTest.cpp
+++ b/uds/clear_dtc/utest/ClearDtcTest.cpp
@@ -26,6 +26,7 @@
 
 #include "../include/ClearDtc.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "Globals.h"
 
 int socket1;
 int socket2;

--- a/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -11,6 +11,7 @@
 #include "FileManager.h"
 #include "NegativeResponse.h"
 #include "SecurityAccess.h"
+#include "Globals.h"
 
 ReadDataByIdentifier::ReadDataByIdentifier(int socket, Logger& rdbi_logger) 
             : generate_frames(socket, rdbi_logger), rdbi_logger(rdbi_logger)

--- a/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
+++ b/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include "../include/ReadDataByIdentifier.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "Globals.h"
 
 int socket1;
 int socket2;

--- a/uds/read_dtc_information/utest/ReadDtcInformationTest.cpp
+++ b/uds/read_dtc_information/utest/ReadDtcInformationTest.cpp
@@ -24,6 +24,7 @@
 #include <sys/ioctl.h>
 #include <gtest/gtest.h>
 #include <net/if.h>
+#include "Globals.h"
 
 int socket_;
 int socket2_;

--- a/uds/routine_control/src/RoutineControl.cpp
+++ b/uds/routine_control/src/RoutineControl.cpp
@@ -15,6 +15,7 @@
 #include "AccessTimingParameter.h"
 #include "RequestDownload.h"
 #include "TransferData.h"
+#include "Globals.h"
 
 RoutineControl::RoutineControl(int socket, Logger& rc_logger)
             : generate_frames(socket, rc_logger), rc_logger(rc_logger)

--- a/uds/routine_control/utest/RoutineControlTest.cpp
+++ b/uds/routine_control/utest/RoutineControlTest.cpp
@@ -10,6 +10,7 @@
 #include <sys/ioctl.h>
 #include <gtest/gtest.h>
 #include <net/if.h>
+#include "Globals.h"
 
 int socket_;
 int socket2_;

--- a/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
+++ b/uds/write_data_by_identifier/src/WriteDataByIdentifier.cpp
@@ -12,6 +12,7 @@
 #include "SecurityAccess.h"
 #include "FileManager.h"
 #include "AccessTimingParameter.h"
+#include "Globals.h"
 
 WriteDataByIdentifier::WriteDataByIdentifier(Logger& wdbi_logger, int socket)
             : generate_frames(socket, wdbi_logger), wdbi_logger(wdbi_logger)

--- a/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
+++ b/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
@@ -8,6 +8,7 @@
 
 #include "../include/WriteDataByIdentifier.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "Globals.h"
 
 int socket1;
 int socket2;

--- a/utils/include/Globals.h
+++ b/utils/include/Globals.h
@@ -1,0 +1,10 @@
+#ifndef GLOBALS_H
+#define GLOBALS_H
+
+#include <string>
+
+extern std::string PROJECT_PATH;
+
+void loadProjectPathForMCU();
+void loadProjectPathForECU();
+#endif

--- a/utils/src/FileManager.cpp
+++ b/utils/src/FileManager.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 
 #include "FileManager.h"
+#include "Globals.h"
 
 void FileManager::writeMapToFile(const std::string& file_name, const std::unordered_map<uint16_t, std::vector<uint8_t>>& data_map)
 {

--- a/utils/src/Globals.cpp
+++ b/utils/src/Globals.cpp
@@ -1,0 +1,39 @@
+#include "Globals.h"
+#include <fstream>
+#include <stdexcept>
+
+std::string PROJECT_PATH;
+
+void loadProjectPathForMCU() {
+    std::ifstream file("../config/config.ini");
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open config.ini");
+    }
+
+    std::string line, key = "PROJECT_PATH=";
+    while (std::getline(file, line)) {
+        if (line.rfind(key, 0) == 0) {
+            PROJECT_PATH = line.substr(key.size());
+            return;
+        }
+    }
+
+    throw std::runtime_error("PROJECT_PATH not found in config.ini");
+}
+
+void loadProjectPathForECU() {
+    std::ifstream file("../../config/config.ini");
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open config.ini");
+    }
+
+    std::string line, key = "PROJECT_PATH=";
+    while (std::getline(file, line)) {
+        if (line.rfind(key, 0) == 0) {
+            PROJECT_PATH = line.substr(key.size());
+            return;
+        }
+    }
+
+    throw std::runtime_error("PROJECT_PATH not found in config.ini");
+}

--- a/utils/test/FileManagerTest.cpp
+++ b/utils/test/FileManagerTest.cpp
@@ -7,6 +7,7 @@
 #include "../include/FileManager.h"
 #include <filesystem>
 #include <cstdio>
+#include "Globals.h"
 
 class FileManagerTest : public testing::Test
 {


### PR DESCRIPTION
- Set up PROJECT_PATH to load at runtime from a config file instead of being hardcoded in the executable. This avoids errors caused by paths specific to the user who built the software. After this change, all users need to add the absolute path to their PoC/src project in the PoC/src/backend/config/config.ini file for PROJECT_PATH to be set correctly.

- Updated the create_sdcard script to always attach the SD card image to /dev/loop1000. This ensures consistency across all users and prevents errors caused by images being mounted on different loop devices.

## Trello link [here](https://trello.com/c/7O365MJA/12-backendminorrequestdownload-after-ota-update)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
