### PR TITLE
Improved OTA functionality: added version check, version sync and update endpoints

### DIFF
--- a/ecu_simulation/BatteryModule/Makefile
+++ b/ecu_simulation/BatteryModule/Makefile
@@ -1,7 +1,8 @@
 ######### Makefile for BatteryModule
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-SOFTWARE_VERSION = 0
+# 16 is 1.0 in hex
+SOFTWARE_VERSION = 16
 PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 
 #Python flags

--- a/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -23,7 +23,7 @@ std::unordered_map<uint16_t, std::vector<uint8_t>> BatteryModule::default_DID_ba
 #ifdef SOFTWARE_VERSION
         {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {static_cast<uint8_t>(SOFTWARE_VERSION)}}
 #else
-        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x00}}
+        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x10}}
 #endif
 };
 const std::vector<uint16_t> BatteryModule::writable_Battery_DID =

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -1,7 +1,8 @@
 ######### Makefile for DoorsModule
 
 #POC Project root path
-SOFTWARE_VERSION = 0
+# 16 is 1.0 in hex
+SOFTWARE_VERSION = 16
 PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8
@@ -12,7 +13,7 @@ PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -l
 # override PYTHON_LDFLAGS = -L/usr/local/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -g -Wall -Werror -pthread \
+CFLAGS = -std=c++17 -O3 -Wall -Werror -pthread \
          -I./include \
          -I../../utils/include \
          -I../../mcu/include \

--- a/ecu_simulation/DoorsModule/src/DoorsModule.cpp
+++ b/ecu_simulation/DoorsModule/src/DoorsModule.cpp
@@ -20,7 +20,7 @@ std::unordered_map<uint16_t, std::vector<uint8_t>> DoorsModule::default_DID_door
 #ifdef SOFTWARE_VERSION
         {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {static_cast<uint8_t>(SOFTWARE_VERSION)}}
 #else
-        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x00}}
+        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x10}}
 #endif
     };
 const std::vector<uint16_t> DoorsModule::writable_Doors_DID =

--- a/ecu_simulation/EngineModule/Makefile
+++ b/ecu_simulation/EngineModule/Makefile
@@ -1,7 +1,8 @@
 ######### Makefile for EngineModule
 
 #POC Project root path
-SOFTWARE_VERSION = 0
+# 16 is 1.0 in hex
+SOFTWARE_VERSION = 16
 PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8

--- a/ecu_simulation/EngineModule/src/EngineModule.cpp
+++ b/ecu_simulation/EngineModule/src/EngineModule.cpp
@@ -37,7 +37,7 @@ std::unordered_map<uint16_t, std::vector<uint8_t>> EngineModule::default_DID_eng
 #ifdef SOFTWARE_VERSION
         {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {static_cast<uint8_t>(SOFTWARE_VERSION)}}
 #else
-        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x00}}
+        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x10}}
 #endif
     };
 const std::vector<uint16_t> EngineModule::writable_Engine_DID =

--- a/ecu_simulation/HVACModule/Makefile
+++ b/ecu_simulation/HVACModule/Makefile
@@ -1,7 +1,8 @@
 ######### Makefile for HVACModule
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-SOFTWARE_VERSION = 0
+# 16 is 1.0 in hex
+SOFTWARE_VERSION = 16
 PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 #Python flags
 PYTHON_INCL_DIR=-I/usr/include/python3.8

--- a/ecu_simulation/HVACModule/src/HVACModule.cpp
+++ b/ecu_simulation/HVACModule/src/HVACModule.cpp
@@ -20,7 +20,7 @@ std::unordered_map<uint16_t, std::vector<uint8_t>> HVACModule::default_DID_hvac 
 #ifdef SOFTWARE_VERSION
         {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {static_cast<uint8_t>(SOFTWARE_VERSION)}}
 #else
-        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x00}}
+        {SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER_DID, {0x10}}
 #endif
     };
 const std::vector<uint16_t> HVACModule::writable_HVAC_DID =

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -1,7 +1,8 @@
 ######### Makefile for MCU module
 ######### Author: Theodor Stoica (contact theodor.stoica@randstaddigital.com for any help)
 
-SOFTWARE_VERSION = 0
+# 16 is 1.0 in hex
+SOFTWARE_VERSION = 16
 PYTHON_ENABLED = 1
 PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION} -DPYTHON_ENABLED=${PYTHON_ENABLED}
 

--- a/rest_api/actions/diag_session.py
+++ b/rest_api/actions/diag_session.py
@@ -20,6 +20,8 @@ class SessionManager(Action):
         Returns:
         - A dictionary with the status and message of the operation.
         """
+        if extra_ecu is None:
+            extra_ecu = 0x10
         ecu_ids = [(API_ID << 8) + 0x10]
         if extra_ecu != 0x10:
             ecu_ids.append(((API_ID << 8) + extra_ecu))

--- a/rest_api/actions/request_id_action.py
+++ b/rest_api/actions/request_id_action.py
@@ -16,6 +16,7 @@ class IDsToJson():
         response = {
             "status": data.get("status"),
             "mcu_id": data.get("mcu_id"),
+            "mcu_version": data.get("mcu_version"),
             "ecus": ecus,
             "time_stamp": datetime.datetime.now().isoformat()
         }
@@ -71,9 +72,21 @@ class RequestIdAction(Action):
                     # Positive response
                     mcu_id = int(f"{data[2]:02X}", 16)
                     ecu_ids = [int(f"{byte:02X}", 16) for byte in data[3:]]
+
+                    # Take mcu version
+                    mcu_id_string = f"{mcu_id:02X}"
+                    formatted_ecu_id = f"0x{mcu_id_string}"
+                    version = self._read_version(formatted_ecu_id)
+                    if version:
+                        formatted_version = ".".join(version)
+                        mcu_version = formatted_version
+                    else:
+                        mcu_version = "no version read"
+
                     data_dict = {
                         "status": "Success",
-                        "mcu_id": f"{mcu_id:02X}",
+                        "mcu_id": mcu_id_string,
+                        "mcu_version": mcu_version,
                         "ecu_ids": [f"{ecu_id:02X}" for ecu_id in ecu_ids]
                     }
                 return data_dict

--- a/rest_api/configs/data_identifiers.py
+++ b/rest_api/configs/data_identifiers.py
@@ -87,6 +87,7 @@ data_identifiers = {
             "oil_temperature": hex(IDENTIFIER_OIL_TEMPERATURE),
             "fuel_pressure": hex(IDENTIFIER_FUEL_PRESSURE),
             "intake_air_temperature": hex(IDENTIFIER_ENGINE_AIR_INTAKE),
+            "mass_air_flow": hex(IDENTIFIER_MASS_AIR_FLOW_MAF_SENSOR)
         },
         "Battery_Identifiers": {
             "battery_level": hex(IDENTIFIER_BATTERY_ENERGY_LEVEL),
@@ -108,7 +109,6 @@ data_identifiers = {
             "ajar": hex(IDENTIFIER_AJAR_STATUS)
         },
         "HVAC_Identifiers": {
-            "mass_air_flow": hex(IDENTIFIER_MASS_AIR_FLOW_MAF_SENSOR),
             "ambient_air_temperature": hex(IDENTIFIER_AMBIENT_AIR_TEMPERATURE),
             "cabin_temperature": hex(IDENTIFIER_CABIN_TEMPERATURE),
             "cabin_temperature_driver_set": hex(IDENTIFIER_CABIN_TEMPERATURE_DRIVER_SET),

--- a/uds/routine_control/src/RoutineControl.cpp
+++ b/uds/routine_control/src/RoutineControl.cpp
@@ -291,6 +291,7 @@ void RoutineControl::routineControl(canid_t can_id, const std::vector<uint8_t>& 
                 return;
             }
             LOG_INFO(rc_logger.GET_LOGGER(), "Current software saved. Activating the new software..");
+            routineControlResponse(can_id, sub_function, routine_identifier, routine_result);
 
             if(activateSoftware() == false)
             {


### PR DESCRIPTION
- Synced the SOFTWARE_VERSION flag with the memory area on the dev loop that stores the program's software version.
- Updated the request_ids endpoint to include the MCU software version in the response.
- Enhanced the /update_to_version endpoint to verify that the target update version is not already running on the ECU/MCU.
- Send a positive response in the backend before updating a module.

## Trello link [here](https://trello.com/c/XyO6NS0v/59-sync-sw-version)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
