### PR TITLE
Orphan process running in background fixed

### DIFF
--- a/ecu_simulation/BatteryModule/src/main.cpp
+++ b/ecu_simulation/BatteryModule/src/main.cpp
@@ -13,6 +13,7 @@ int main() {
     batteryModuleLogger = new Logger("batteryModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/BatteryModule/logs/batteryModuleLogger.log");
     #endif /* UNIT_TESTING_MODE */
     battery = new BatteryModule();
+    battery->_ecu->stopProcess("main_battery");
     std::thread receiveFrThread([]()
                                { battery->_ecu->startFrames(); });
     sleep(200);

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -8,12 +8,12 @@ PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 
-# Uncomment this lines in production when running on Raspberry Pi
+# Uncomment this lines in production whegitn running on Raspberry Pi
 # override PYTHON_INCL_DIR=-I/usr/local/include/python3.8
 # override PYTHON_LDFLAGS = -L/usr/local/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -O3 -Wall -Werror -pthread \
+CFLAGS = -std=c++17 -g -Wall -Werror -pthread \
          -I./include \
          -I../../utils/include \
          -I../../mcu/include \

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -8,7 +8,7 @@ PROJECT_DEFINES = -DSOFTWARE_VERSION=${SOFTWARE_VERSION}
 PYTHON_INCL_DIR=-I/usr/include/python3.8
 PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 
-# Uncomment this lines in production whegitn running on Raspberry Pi
+# Uncomment this lines in production when running on Raspberry Pi
 # override PYTHON_INCL_DIR=-I/usr/local/include/python3.8
 # override PYTHON_LDFLAGS = -L/usr/local/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -ldl -lutil -lm -lpthread
 # Compiler flags

--- a/ecu_simulation/DoorsModule/src/main.cpp
+++ b/ecu_simulation/DoorsModule/src/main.cpp
@@ -13,6 +13,7 @@ int main() {
     doorsModuleLogger = new Logger("doorsModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/DoorsModule/logs/doorsModuleLogger.log");
     #endif /* UNIT_TESTING_MODE */
     doors = new DoorsModule();
+    doors->_ecu->stopProcess("main_doors");
     std::thread receiveFrThread([]()
                                { doors->_ecu->startFrames(); });
     sleep(200);

--- a/ecu_simulation/EngineModule/src/main.cpp
+++ b/ecu_simulation/EngineModule/src/main.cpp
@@ -13,6 +13,7 @@ int main() {
     engineModuleLogger = new Logger("engineModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/logs/engineModuleLogger.log");
     #endif /* UNIT_TESTING_MODE */
     engine = new EngineModule();
+    engine->_ecu->stopProcess("main_engine");
     std::thread receiveFrThread([]()
                                { engine->_ecu->startFrames(); });
     sleep(200);

--- a/ecu_simulation/HVACModule/src/main.cpp
+++ b/ecu_simulation/HVACModule/src/main.cpp
@@ -15,6 +15,7 @@ int main()
     #endif
 
     hvac = new HVACModule();
+    hvac->_ecu->stopProcess("main_hvac");
     hvac->printHvacInfo();
     std::thread receiveFrThread([]()
                                { hvac->_ecu->startFrames(); });

--- a/mcu/include/MCUModule.h
+++ b/mcu/include/MCUModule.h
@@ -113,6 +113,11 @@ namespace MCU
          * 
          */
         void fetchMCUData();
+        /**
+         * @brief This function stops all the processes that running ./main_mcu, except the current one.
+         * 
+         */
+        void stopProcess();
  
     private:
         bool is_running;

--- a/mcu/src/MCUModule.cpp
+++ b/mcu/src/MCUModule.cpp
@@ -343,10 +343,10 @@ namespace MCU
         /* Read the output of the command and check if it is valid */
         if (fscanf(fp, "%d", &count) != 1) {
             std::cerr << "Failed to read process count" << std::endl;
-            fclose(fp);
+            pclose(fp);
             return;
         }
-        fclose(fp);
+        pclose(fp);
 
         /* Loop while there are more than 2 processes running */
         while (count > 2) {
@@ -368,10 +368,10 @@ namespace MCU
             }
             if (fscanf(fp, "%d", &count) != 1) {
                 std::cerr << "Failed to read process count" << std::endl;
-                fclose(fp);
+                pclose(fp);
                 return;
             }
-            fclose(fp);
+            pclose(fp);
         }
     }
 }

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -14,6 +14,7 @@ int main() {
     MCULogger = new Logger;
     #endif /* UNIT_TESTING_MODE */
     MCU::mcu = new MCU::MCUModule(0x01);
+    MCU::mcu->stopProcess();
     MCU::mcu->StartModule();
     std::thread receiveFrThread([]()
     { 

--- a/utils/include/ECU.h
+++ b/utils/include/ECU.h
@@ -77,6 +77,8 @@ public:
      * 
      */
     ~ECU();
+
+    void stopProcess(std::string process_name);
 };
 
 #endif

--- a/utils/src/ECU.cpp
+++ b/utils/src/ECU.cpp
@@ -120,10 +120,10 @@ void ECU::stopProcess(std::string process_name)
     /* Read the output of the command and check if it is valid */
     if (fscanf(fp, "%d", &count) != 1) {
         std::cerr << "Failed to read process count" << std::endl;
-        fclose(fp);
+        pclose(fp);
         return;
     }
-    fclose(fp);
+    pclose(fp);
 
     /* Loop while there are more than 2 processes running */
     while (count > 2) {
@@ -145,9 +145,9 @@ void ECU::stopProcess(std::string process_name)
         }
         if (fscanf(fp, "%d", &count) != 1) {
             std::cerr << "Failed to read process count" << std::endl;
-            fclose(fp);
+            pclose(fp);
             return;
         }
-        fclose(fp);
+        pclose(fp);
     }
 }

--- a/utils/src/ECU.cpp
+++ b/utils/src/ECU.cpp
@@ -106,3 +106,48 @@ ECU::~ECU()
     delete _frame_receiver;
     /* LOG */
 }
+
+void ECU::stopProcess(std::string process_name)
+{
+    /* Use popen to capture the output of the command */
+    FILE* fp = popen(("pgrep -f '" + process_name + "' | wc -l").c_str(), "r");
+    if (fp == nullptr) {
+        std::cerr << "Failed to run command" << std::endl;
+        return;
+    }
+
+    int count = 0;
+    /* Read the output of the command and check if it is valid */
+    if (fscanf(fp, "%d", &count) != 1) {
+        std::cerr << "Failed to read process count" << std::endl;
+        fclose(fp);
+        return;
+    }
+    fclose(fp);
+
+    /* Loop while there are more than 2 processes running */
+    while (count > 2) {
+        std::cout << "More than one process found. Killing old instances..." << std::endl;
+
+        /* Kill the oldest process */
+        int result = system(("pkill -o -f '" + process_name + "'").c_str());
+        if (result == 0) {
+            std::cout << "Old process terminated successfully." << std::endl;
+        } else {
+            std::cerr << "Failed to terminate old process." << std::endl;
+        }
+
+        /* Reload the process count after killing one process */
+        fp = popen(("pgrep -f '" + process_name + "' | wc -l").c_str(), "r");
+        if (fp == nullptr) {
+            std::cerr << "Failed to run command" << std::endl;
+            return;
+        }
+        if (fscanf(fp, "%d", &count) != 1) {
+            std::cerr << "Failed to read process count" << std::endl;
+            fclose(fp);
+            return;
+        }
+        fclose(fp);
+    }
+}


### PR DESCRIPTION
- Added a function to each module that is called at the start of the program to terminate all processes running the current program's executable, except for the current process. This ensures orphaned processes left running in the background after an update_to_version are properly terminated.

## Trello link [here](https://trello.com/c/m73DJ1Ir/43-process-not-stopping)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
