### PR TITLE
Improve .gitignore and Automate config.ini Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,22 @@ rest_api/utils/__pycache__
 # remove rest api loggers
 rest_api/utils/log*
 
+# ignore result data files
+*_data.txt
+dtcs.txt
+
+# ignore generated log files
+logs/
+
+# ignore main binary files
+main_*
+
+# ignore pip installer script
+rest_api/get-pip.py
+
+# Ignore config files
+config/config.ini
+
 #remove db api
 rest_api/instance/db.sqlite
 

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,0 +1,3 @@
+.PHONY: config_init
+init:
+	python3 generate_config.py

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,3 +1,0 @@
-# Set your own project path like PROJECT_PATH=/home/nicu/Desktop/PoC_submodules/PoC/src
-[Paths]
-PROJECT_PATH=

--- a/config/generate_config.py
+++ b/config/generate_config.py
@@ -1,0 +1,19 @@
+import os
+import configparser
+
+config_file = "config.ini"
+
+# Move two directories up
+project_path = os.path.abspath(os.path.join(os.getcwd(), "..", ".."))
+
+config = configparser.ConfigParser()
+config.optionxform = str
+
+config["Paths"] = {"PROJECT_PATH": project_path}
+
+# Overwrite or create config.ini
+with open(config_file, "w") as file:
+    for section in config.sections():
+        file.write(f"[{section}]\n")
+        for key, value in config[section].items():
+            file.write(f"{key}={value}\n")

--- a/ecu_simulation/BatteryModule/Makefile
+++ b/ecu_simulation/BatteryModule/Makefile
@@ -59,6 +59,10 @@ HVAC_DIR = ../HVACModule/src
 OTA_DIR = ../../ota
 OBJ_DIR = obj
 
+# Build config
+all:
+	$(MAKE) -C ../../config init
+
 #----------------------------------------------------MCU MODULE-----------------------------------------------------
 
 # Object files

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -58,6 +58,10 @@ HVAC_DIR = ../HVACModule/src
 OTA_DIR = ../../ota
 OBJ_DIR = obj
 
+# Build config
+all:
+	$(MAKE) -C ../../config init
+
 #----------------------------------------------------MCU MODULE-----------------------------------------------------
 
 # Object files

--- a/ecu_simulation/EngineModule/Makefile
+++ b/ecu_simulation/EngineModule/Makefile
@@ -55,6 +55,10 @@ HVAC_DIR = ../HVACModule/src
 OTA_DIR = ../../ota
 OBJ_DIR = obj
 
+# Build config
+all:
+	$(MAKE) -C ../../config init
+
 #----------------------------------------------------ENGINE MODULE-----------------------------------------------------
 
 # Object files

--- a/ecu_simulation/HVACModule/Makefile
+++ b/ecu_simulation/HVACModule/Makefile
@@ -54,6 +54,10 @@ DOORS_DIR = ../DoorsModule/src
 OTA_DIR = ../../ota
 OBJ_DIR = obj
 
+# Build config
+all:
+	$(MAKE) -C ../../config init
+
 #----------------------------------------------------MCU MODULE-----------------------------------------------------
 
 # Object files

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -65,6 +65,10 @@ OTA_DIR = ../ota
 OBJ_DIR = obj
 HVAC_DIR_TEST = ../ecu_simulation/HVACModule/test
 
+# Build config
+all:
+	$(MAKE) -C ../config init
+
 #----------------------------------------------------MCU MODULE-----------------------------------------------------
 
 # Object files


### PR DESCRIPTION
## Description

This MR updates .gitignore to exclude generated binaries logs and result files to prevent unnecessary tracking it also adds an automated generation of config.ini in the Makefile eliminating the need for manual tracking and updates dependent Makefiles to ensure config.ini is correctly triggered during the build .

## Trello [link](https://trello.com/c/GOP43u8j)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
