### PR TITLE
fix: add missing includes, delete obsolete tests, link missing object…

### DIFF
--- a/ecu_simulation/BatteryModule/test/BatteryModuleTest.cpp
+++ b/ecu_simulation/BatteryModule/test/BatteryModuleTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+#include <fstream>
 #include "../include/BatteryModule.h"
+#include "../../../utils/include/FileManager.h"
 #include "Globals.h"
 
 bool containsLine(const std::string& output, const std::string& line)

--- a/ecu_simulation/DoorsModule/test/DoorsModuleTest.cpp
+++ b/ecu_simulation/DoorsModule/test/DoorsModuleTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <fstream>
 #include "../include/DoorsModule.h"
 
 bool containsLine(const std::string& output, const std::string& line)

--- a/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
+++ b/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <fstream>
 #include "../include/EngineModule.h"
 #include "Globals.h"
 

--- a/ecu_simulation/HVACModule/test/HVACModuleTest.cpp
+++ b/ecu_simulation/HVACModule/test/HVACModuleTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <fstream>
 #include "../include/HVACModule.h"
 
 bool containsLine(const std::string& output, const std::string& line)

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -16,7 +16,7 @@ PYTHON_LDFLAGS = -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -l
 
 # Compiler flags
 CXX = g++
-CFLAGS = -std=c++17 -O3 -Wall -Werror -pthread \
+CFLAGS = -std=c++17 -O3 -Wall -Wno-unused-result -Werror -pthread \
          -I../include \
          -I./include \
          -I../utils/include \
@@ -254,6 +254,7 @@ UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/Logger_test.o \
                   $(OBJ_DIR)/CreateInterface_test.o \
                   $(OBJ_DIR)/GenerateFrames_test.o \
+				  $(OBJ_DIR)/Globals_test.o \
                   $(OBJ_DIR)/NegativeResponse_test.o \
                   $(OBJ_DIR)/HandleFrames_test.o \
 				  $(OBJ_DIR)/ReceiveFrames_test_utils.o \
@@ -379,6 +380,9 @@ $(OBJ_DIR)/ECU_test.o: $(UTILS_DIR)/ECU.cpp
 
 $(OBJ_DIR)/GenerateFrames_test.o: $(UTILS_DIR)/GenerateFrames.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_DIR)/GenerateFrames.cpp -o $(OBJ_DIR)/GenerateFrames_test.o $(CFLAGSTST2) $(LDFLAGS)
+
+$(OBJ_DIR)/Globals_test.o: $(UTILS_DIR)/Globals.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_DIR)/Globals.cpp -o $(OBJ_DIR)/Globals_test.o $(CFLAGSTST2) $(LDFLAGS)
 
 $(OBJ_DIR)/HandleFrames_test.o: $(UTILS_DIR)/HandleFrames.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UTILS_DIR)/HandleFrames.cpp -o $(OBJ_DIR)/HandleFrames_test.o $(CFLAGSTST2) $(LDFLAGS)
@@ -593,8 +597,8 @@ $(UDS_DIR)/read_data_by_identifier/utest/ReadDataByIdentifier_test.o: $(UDS_DIR)
 # RequestTransferExit Unit tests
 requestTransferExitTest: $(OBJ_DIR) $(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out
 
-$(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out: $(OBJ_DIR) $(OBJS_REQUESTTRANSFEREXIT_TEST) $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o
-	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o $(OBJS_REQUESTTRANSFEREXIT_TEST) $(CFLAGSTST2) $(LDFLAGS)
+$(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o
+	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
 
 $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o: $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExitTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExitTest.cpp -o $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o $(CFLAGSTST2) $(LDFLAGS)
@@ -626,8 +630,8 @@ $(UDS_DIR)/clear_dtc/utest/ClearDtc_test.o: $(UDS_DIR)/clear_dtc/utest/ClearDtcT
 # RequestUpdateStatus Unit tests
 requestUpdateStatusTest: $(OBJ_DIR) $(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out
 
-$(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out: $(OBJ_DIR) $(OBJS_REQUESTUPDATESTATUS_TEST) $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o
-	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o $(OBJS_REQUESTUPDATESTATUS_TEST) $(CFLAGSTST2) $(LDFLAGS)
+$(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o
+	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
 
 $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o: $(OTA_DIR)/request_update_status/utest/RequestUpdateStatusTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(OTA_DIR)/request_update_status/utest/RequestUpdateStatusTest.cpp -o $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o $(CFLAGSTST2) $(LDFLAGS)
@@ -692,8 +696,8 @@ $(DOORS_DIR_TEST)/doorsModule_test.o: $(DOORS_DIR_TEST)/DoorsModuleTest.cpp
 # RequestDownload Unit tests
 requestDownloadTest: $(OBJ_DIR) $(OTA_DIR)/request_download/utest/requestDownloadTest.out
 
-$(OTA_DIR)/request_download/utest/requestDownloadTest.out: $(OBJ_DIR) $(OBJS_REQUESTDOWNLOAD_TEST) $(OTA_DIR)/request_download/utest/RequestDownload_test.o
-	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_download/utest/requestDownloadTest.out $(OTA_DIR)/request_download/utest/RequestDownload_test.o $(OBJS_REQUESTDOWNLOAD_TEST) $(CFLAGSTST2) $(LDFLAGS)
+$(OTA_DIR)/request_download/utest/requestDownloadTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_download/utest/RequestDownload_test.o
+	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/request_download/utest/requestDownloadTest.out $(OTA_DIR)/request_download/utest/RequestDownload_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
 
 $(OTA_DIR)/request_download/utest/RequestDownload_test.o: $(OTA_DIR)/request_download/utest/RequestDownloadTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(OTA_DIR)/request_download/utest/RequestDownloadTest.cpp -o $(OTA_DIR)/request_download/utest/RequestDownload_test.o $(CFLAGSTST2) $(LDFLAGS)
@@ -703,8 +707,8 @@ $(OTA_DIR)/request_download/utest/RequestDownload_test.o: $(OTA_DIR)/request_dow
 # TransferData Unit tests
 transferDataTest: $(OBJ_DIR) $(OTA_DIR)/transfer_data/utest/transferDataTest.out
 
-$(OTA_DIR)/transfer_data/utest/transferDataTest.out: $(OBJ_DIR) $(OBJS_TRANSFERDATA_TEST) $(OTA_DIR)/transfer_data/utest/TransferData_test.o
-	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/transfer_data/utest/transferDataTest.out $(OTA_DIR)/transfer_data/utest/TransferData_test.o $(OBJS_TRANSFERDATA_TEST) $(CFLAGSTST2) $(LDFLAGS)
+$(OTA_DIR)/transfer_data/utest/transferDataTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/transfer_data/utest/TransferData_test.o
+	$(CXX) $(CFLAGSTST) -o $(OTA_DIR)/transfer_data/utest/transferDataTest.out $(OTA_DIR)/transfer_data/utest/TransferData_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
 
 $(OTA_DIR)/transfer_data/utest/TransferData_test.o: $(OTA_DIR)/transfer_data/utest/TransferDataTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(OTA_DIR)/transfer_data/utest/TransferDataTest.cpp -o $(OTA_DIR)/transfer_data/utest/TransferData_test.o $(CFLAGSTST2) $(LDFLAGS)

--- a/ota/request_download/utest/RequestDownloadTest.cpp
+++ b/ota/request_download/utest/RequestDownloadTest.cpp
@@ -1,0 +1,7 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/ota/request_update_status/utest/RequestUpdateStatusTest.cpp
+++ b/ota/request_update_status/utest/RequestUpdateStatusTest.cpp
@@ -1,14 +1,16 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "../include/RequestUpdateStatus.h"
+#include "../../../uds/access_timing_parameters/include/AccessTimingParameter.h"
 #include "../../../uds/write_data_by_identifier/include/WriteDataByIdentifier.h"
 #include "../../../mcu/include/MCUModule.h"
+#include "../../../utils/include/NegativeResponse.h"
 
 class RequestUpdateStatusTest : public ::testing::Test {
 protected:
     int socket_id = 2;
     Logger logger;
-    RequestUpdateStatus RUS = RequestUpdateStatus(socket_id);
+    RequestUpdateStatus RUS = RequestUpdateStatus(socket_id, logger);
 
     RequestUpdateStatusTest()
     {
@@ -60,7 +62,7 @@ TEST_F(RequestUpdateStatusTest, WrongSenderReceiverCheckTest)
     std::vector<uint8_t> expected_response = {PCI_L, REQUEST_UPDATE_STATUS_SID_SUCCESS, IDLE};
 
     EXPECT_EQ(response.size(), expected_response.size());
-    for(uint8_t index; index <= expected_response.size() - 1; index++)
+    for(uint8_t index = 0; index <= expected_response.size() - 1; index++)
     {
         EXPECT_EQ(response[index], expected_response[index]);
     }
@@ -80,7 +82,7 @@ TEST_F(RequestUpdateStatusTest, InitialOtaStatusTest)
     std::vector<uint8_t> expected_response = {PCI_L, REQUEST_UPDATE_STATUS_SID_SUCCESS, IDLE};
 
     EXPECT_EQ(response.size(), expected_response.size());
-    for(uint8_t index; index <= expected_response.size() - 1; index++)
+    for(uint8_t index = 0; index <= expected_response.size() - 1; index++)
     {
         EXPECT_EQ(response[index], expected_response[index]);
     }
@@ -104,7 +106,7 @@ TEST_F(RequestUpdateStatusTest, AfterStatusUpdateTest)
     std::vector<uint8_t> expected_response = {PCI_L, REQUEST_UPDATE_STATUS_SID_SUCCESS, new_status};
     
     EXPECT_EQ(response.size(), expected_response.size());
-    for(uint8_t index; index <= expected_response.size() - 1; index++)
+    for(uint8_t index = 0; index <= expected_response.size() - 1; index++)
     {
         EXPECT_EQ(response[index], expected_response[index]);
     }
@@ -128,7 +130,7 @@ TEST_F(RequestUpdateStatusTest, NegativeResponseInvalidStatusTest)
     std::vector<uint8_t> expected_response = {PCI_L, NEGATIVE_RESPONSE, REQUEST_UPDATE_STATUS_SID, REQUEST_OUT_OF_RANGE};
     
     EXPECT_EQ(response.size(), expected_response.size());
-    for(uint8_t index; index <= expected_response.size() - 1; index++)
+    for(uint8_t index = 0; index <= expected_response.size() - 1; index++)
     {
         EXPECT_EQ(response[index], expected_response[index]);
     }

--- a/uds/authentication/utest/SecurityAccessTest.cpp
+++ b/uds/authentication/utest/SecurityAccessTest.cpp
@@ -6,6 +6,7 @@
  * @date 2024-07-16
  */
 #include "../include/SecurityAccess.h"
+#include "../../../utils/include/NegativeResponse.h"
 
 #include <cstring>
 #include <string>

--- a/uds/clear_dtc/utest/ClearDtcTest.cpp
+++ b/uds/clear_dtc/utest/ClearDtcTest.cpp
@@ -26,6 +26,8 @@
 
 #include "../include/ClearDtc.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../../uds/authentication/include/SecurityAccess.h"
 #include "Globals.h"
 
 int socket1;

--- a/uds/ecu_reset/utest/EcuResetTest.cpp
+++ b/uds/ecu_reset/utest/EcuResetTest.cpp
@@ -5,9 +5,17 @@
  * @version 0.1
  * @date 2024-10-11
  */
+#include <cstddef>
+#include <fcntl.h>
+#include <memory>
 #include <gtest/gtest.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <sys/socket.h>
 #include "../include/EcuReset.h"
+#include "../../authentication/include/SecurityAccess.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "../../../utils/include/NegativeResponse.h"
 
 int socket1;
 int socket2;
@@ -119,12 +127,11 @@ struct EcuResetTest : testing::Test
 
 TEST_F(EcuResetTest, ConstructorInitializesFieldsCorrectly)
 {
-    EcuReset *ecuReset;
+    std::unique_ptr<EcuReset> ecuReset;
     EXPECT_NO_THROW(
     {
-        ecuReset = new EcuReset(0xFA10, 0x01, socket2, *logger);
+        ecuReset = std::make_unique<EcuReset>(0xFA10, 0x01, socket2, *logger);
     });
-    delete ecuReset;
 }
 
 TEST_F(EcuResetTest, IncorrectMessageLength)

--- a/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
+++ b/uds/read_data_by_identifier/utest/ReadDataByIdentifierTest.cpp
@@ -5,9 +5,16 @@
  * @version 0.1
  * @date 2024-10-9
  */
+#include <fcntl.h>
+#include <fstream>
 #include <gtest/gtest.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
 #include "../include/ReadDataByIdentifier.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../../uds/authentication/include/SecurityAccess.h"
 #include "Globals.h"
 
 int socket1;

--- a/uds/read_dtc_information/utest/ReadDtcInformationTest.cpp
+++ b/uds/read_dtc_information/utest/ReadDtcInformationTest.cpp
@@ -17,6 +17,7 @@
 #include "../include/ReadDtcInformation.h"
 
 #include <cstring>
+#include <linux/can.h>
 #include <string>
 #include <thread>
 

--- a/uds/routine_control/utest/RoutineControlTest.cpp
+++ b/uds/routine_control/utest/RoutineControlTest.cpp
@@ -1,6 +1,8 @@
 #include "../include/RoutineControl.h"
 #include "../../diagnostic_session_control/include/DiagnosticSessionControl.h"
 #include "../../utils/include/FileManager.h"
+#include "../../utils/include/NegativeResponse.h"
+#include "../../authentication/include/SecurityAccess.h"
 
 #include <cstring>
 #include <string>
@@ -292,9 +294,11 @@ TEST_F(RoutineControlTest, SaveCurrentSoftwareFailed)
     testFrames(expected_frame, *capture_frame);
 }
 
-TEST_F(RoutineControlTest, Rollback)
+TEST_F(RoutineControlTest, DISABLED_Rollback)
 { 
-    EXPECT_EQ(routine_control->activateSoftware(), 0);
+    // TODO: rework this test as activateSoftware is a private method
+    // which is only called inside RoutineControl's ctor
+    // EXPECT_EQ(routine_control->activateSoftware(), 0);
 }
 
 int main(int argc, char* argv[])

--- a/uds/tester_present/utest/TesterPresentTest.cpp
+++ b/uds/tester_present/utest/TesterPresentTest.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "../include/TesterPresent.h"
+#include "../../../utils/include/NegativeResponse.h"
 #include <cstring>
 #include <string>
 #include <thread>

--- a/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
+++ b/uds/write_data_by_identifier/utest/WriteDataByIdentifierTest.cpp
@@ -2,12 +2,15 @@
 #include <string>
 #include <thread>
 #include <fcntl.h>
+#include <fstream>
 #include <sys/ioctl.h>
 #include <gtest/gtest.h>
 #include <net/if.h>
 
 #include "../include/WriteDataByIdentifier.h"
+#include "../../../uds/authentication/include/SecurityAccess.h"
 #include "../../../utils/include/ReceiveFrames.h"
+#include "../../../utils/include/NegativeResponse.h"
 #include "Globals.h"
 
 int socket1;

--- a/utils/test/GenerateFramesTest.cpp
+++ b/utils/test/GenerateFramesTest.cpp
@@ -1,6 +1,7 @@
 #include "../include/GenerateFrames.h"
 
 #include <gtest/gtest.h>
+#include <linux/can.h>
 #include <net/if.h>
 #include <cstring>
 #include <string>

--- a/utils/test/HandleFramesTest.cpp
+++ b/utils/test/HandleFramesTest.cpp
@@ -3,6 +3,7 @@
 #include "../../uds/diagnostic_session_control/include/DiagnosticSessionControl.h"
 #include <linux/can.h>
 #include "../include/MCULogger.h"
+#include "../../uds/tester_present/include/TesterPresent.h"
 
 Logger logger;
 int skt = 1;
@@ -546,7 +547,7 @@ TEST_F(HandleFramesTest, WrongConsecutiveFrames)
 
 TEST_F(HandleFramesTest, ConsecutiveFrames)
 {
-    struct can_frame testFrame = createFrame({0x21, 0x08,0x05,0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x10,0x11});
+    struct can_frame testFrame = createFrame({0x21, 0x08,0x05,0x11,0x11,0x11});
     testing::internal::CaptureStdout();
     handler.handleFrame(skt, testFrame);
     std::string output = testing::internal::GetCapturedStdout();

--- a/utils/test/MemoryManagerTest.cpp
+++ b/utils/test/MemoryManagerTest.cpp
@@ -11,6 +11,7 @@
 #include "../include/MemoryManager.h"
 
 #include <gtest/gtest.h>
+#include <fstream>
 
 off_t address = 100000 * 512;
 Logger* logger = new Logger("test","test_memory.log");

--- a/utils/test/NegativeResponseTest.cpp
+++ b/utils/test/NegativeResponseTest.cpp
@@ -8,6 +8,7 @@
 #include "../include/NegativeResponse.h"
 
 #include <cstring>
+#include <linux/can.h>
 #include <string>
 #include <thread>
 

--- a/utils/test/ReceiveFramesTest.cpp
+++ b/utils/test/ReceiveFramesTest.cpp
@@ -253,7 +253,7 @@ TEST_F(ReceiveFramesTest, StopEngine)
 {
     std::cerr << "Running StopEngine" << std::endl;
     testing::internal::CaptureStdout();
-    r->startTimer(0x12, 0x10);
+    r->startTimer(0x12, 0x10, 10);
     sleep(3);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_NE(output.find("Service with SID 10 sent the response pending frame."), std::string::npos);
@@ -264,7 +264,7 @@ TEST_F(ReceiveFramesTest, StopDoors)
 {
     std::cerr << "Running StopDoors" << std::endl;
     testing::internal::CaptureStdout();
-    r->startTimer(0x13, 0x10);
+    r->startTimer(0x13, 0x10, 10);
     sleep(3);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_NE(output.find("Service with SID 10 sent the response pending frame."), std::string::npos);
@@ -275,7 +275,7 @@ TEST_F(ReceiveFramesTest, StopHVAC)
 {
     std::cerr << "Running StopHVAC" << std::endl;
     testing::internal::CaptureStdout();
-    r->startTimer(0x14, 0x10);
+    r->startTimer(0x14, 0x10, 10);
     sleep(3);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_NE(output.find("Service with SID 10 sent the response pending frame."), std::string::npos);
@@ -286,7 +286,7 @@ TEST_F(ReceiveFramesTest, StopTimerDefaultCase)
 {
     std::cerr << "Running StopTimerDefaultCase" << std::endl;
     testing::internal::CaptureStdout();
-    r->stopTimer(0x15, 0x10);
+    r->stopTimer(0x15, 0x10, 10);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_NE(output.find("stopTimer function called with an ecu id unknown 15."), std::string::npos);
     std::cerr << "Finished StopTimerDefaultCase" << std::endl;


### PR DESCRIPTION
## Description

Running `make allTests` led to multiple failures. In order to ensure that the test executables are built, I did the following:

1. Add missing includes: Test files were missing multiple includes of both project files (for instance FileManager.h inside BatteryModuleTests) and external dependencies (including but not limited to linux/can.h for the can_frame struct or sys/ioctl.h and net/if.h for the ifreq struct)
2. Delete deprecated tests: Several tests were using methods that no longer exist (for instance MCUModuleTest::setDIDValue).
3. Link missing object files: In the MCU and ECU tests, the project path was an undefined reference. Calling the respective loadProjectPath functions from the test constructor lead to undefined reference. Similarly, in a lot of the utils tests, mcu/ecu and utils classes were undefined references. To solve this, I created a new Globals_test object file and added it to UTILS_OBJS_TEST, and linked all OBJS_TEST to the utils tests that were failing
4. Fix unit tests: Some unit tests would not build as function calls did not have all necessary parameters (for instance receive_frames::start/stop_timer in the ReceiveFramesTest suite). Initialized indexes in RequestUpdateStatusTest to avoid failure due to uninitialized variable. Replaced the raw pointer from EcuResetTest::ConstructorInitializesFieldsCorrectly with a smart pointer to avoid the failure caused by the warning maybe-uninitialized when deleting the pointer. Finally, I reduced the test-data size used for creating a new frame in HandleFramesTest::ConsecutiveFrames as it lead to failure to compile due to -Waggressive-loop-optimizations (max data length of a can frame is 8). This last change does not lead to the test failing.
5. Renamed request_download.cpp to RequestDownloadTest.cpp (as expected by the requestDownloadTest executable in the MakeFile)
6. Added -Wno-unused-result to prevent failure of tests who call methods that return values which are not necessary

I disabled and commented RoutineControlTest::Rollback as it calls a private method of RoutineControl. Fixing this test falls outside of the scope of this task and should be reworked as part of [](https://trello.com/c/xpfNQGn1/44-continuous-rollback-crashes-the-program)

After all the aforementioned changes, all test executables can be compiled

## Trello link [here](https://trello.com/c/okZ7ahWr/60-cannot-run-alltests)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
