### PR TITLE
Ensure battery data is updated before reading

### DIFF
--- a/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
+++ b/uds/read_data_by_identifier/src/ReadDataByIdentifier.cpp
@@ -88,6 +88,10 @@ std::vector<uint8_t> ReadDataByIdentifier::readDataByIdentifier(canid_t frame_id
     }
     else if (lowerbits == 0x11)
     {
+        if (battery)
+        {
+            battery->fetchBatteryData("r");
+        }
         file_name += "/backend/ecu_simulation/BatteryModule/battery_data.txt";
     }
     else if (lowerbits == 0x12)


### PR DESCRIPTION
## Description

This MR introduces a call to fetchBatteryData("r") in readDataByIdentifier to ensure battery data is always up to date before being read.

⚠️ Note: Failures related to pipes build are caused by the latest update from GitHub
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


## Trello [link](https://trello.com/c/IffjKSCh)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
