### PR TITLE
Fix displayed battery value

### DIFF
--- a/ecu_simulation/BatteryModule/src/BatteryModule.cpp
+++ b/ecu_simulation/BatteryModule/src/BatteryModule.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <sstream>
 #include <fstream>
 #include <iomanip>
@@ -124,20 +125,11 @@ void BatteryModule::parseBatteryInfo(const std::string &data, float &energy, flo
         else if (line.find("percentage:") != std::string::npos)
         {
             percentage = std::stof(line.substr(line.find(":") + 1));
-            uint8_t percentage_value = static_cast<uint8_t>(percentage);
-            std::string percentage_str = std::to_string(percentage_value);
-            if (percentage_str.size() % 2 != 0) {
-                percentage_str = "0" + percentage_str;
-            }
-            std::string percentage_grouped;
-            for (size_t i = 0; i < percentage_str.size(); i += 2) {
-                percentage_grouped += percentage_str.substr(i, 2) + " ";
-            }
-            int decimal_value = std::stoi(percentage_grouped);
+            uint16_t percentage_value = static_cast<uint16_t>(percentage);
             std::stringstream data_ss;
-            data_ss << std::hex << std::setw(2) << std::setfill('0') << std::uppercase << decimal_value;
-            percentage_grouped = data_ss.str();
-            updated_values[0x01C0] = percentage_grouped;
+            data_ss << std::hex << std::setw(2) << std::setfill('0') << std::uppercase << percentage_value;
+            std::string percentage_str = data_ss.str();
+            updated_values[0x01C0] = percentage_str;
         }
         else if (line.find("state:") != std::string::npos)
         {


### PR DESCRIPTION
## Description

Root of the issue of battery percentage being displayed as 1 instead of 100 laid in the parsing of battery data inside the battery module. After splitting the digits of the decimal value of the percentage in groups of 2, the decimal_value variable would actually store 1 instead of 100. In order to fix this issue, I simplified the code for converting the battery percentage to a hex string by removing the extra percentage_grouped and decimal_value, working directly on percentage_value. I found it necessary to change the datatype of percentage_value from uint8_t to uint16_t as the percentage_value behaved as a char.

With my changes, I started the MCU, BatteryModule (I have the laptop battery at 100%), rest_api and frontend. In the UDS/Battery page, the battery percentage is 100%

## Trello link [here](https://trello.com/c/7VlIKNXP/45-backendmoderate-battery-percentage-is-showing-1-instead-of-100-when-fully-charged)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
