### PR TITLE
chore: upgrade actions from v3 to v4

### DIFF
--- a/.github/workflows/build_checker.yml
+++ b/.github/workflows/build_checker.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache APT Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /var/cache/apt
           key: ${{ runner.os }}-apt-cache
@@ -32,7 +32,7 @@ jobs:
           make
 
       - name: Upload MCU Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mcu_build
           path: mcu/build  # Adjust path if needed
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache APT Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /var/cache/apt
           key: ${{ runner.os }}-apt-cache
@@ -63,7 +63,7 @@ jobs:
           make
 
       - name: Upload Battery Module Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: battery_module_build
           path: ecu_simulation/BatteryModule/build
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache APT Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /var/cache/apt
           key: ${{ runner.os }}-apt-cache
@@ -94,7 +94,7 @@ jobs:
           make
 
       - name: Upload Doors Module Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doors_module_build
           path: ecu_simulation/DoorsModule/build
@@ -103,10 +103,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache APT Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /var/cache/apt
           key: ${{ runner.os }}-apt-cache
@@ -125,7 +125,7 @@ jobs:
           make
 
       - name: Upload Engine Module Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: engine_module_build
           path: ecu_simulation/EngineModule/build
@@ -134,10 +134,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache APT Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /var/cache/apt
           key: ${{ runner.os }}-apt-cache
@@ -156,7 +156,7 @@ jobs:
           make
 
       - name: Upload HVAC Module Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hvac_module_build
           path: ecu_simulation/HVACModule/build
@@ -166,7 +166,7 @@ jobs:
     needs: [mcu_build, battery_module_build, doors_module_build, engine_module_build, hvac_module_build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check Build Results
         run: echo "All modules built successfully."


### PR DESCRIPTION
## Description

Github actions v3 is deprecated, leading to pipeline failures. The aim of this fix is to upgrade to v4 to prevent hiding failures caused by our errors

## Trello link [here](put here the link)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
