### PR TITLE
fix: add Globals test object file

### DIFF
--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -262,7 +262,8 @@ UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
                   $(OBJ_DIR)/FileManager_test.o
 
 OBJS_GENERATE_TEST = $(OBJ_DIR)/Logger_test.o \
-                  	 $(OBJ_DIR)/GenerateFrames_test.o
+                  	 $(OBJ_DIR)/GenerateFrames_test.o \
+					 $(OBJ_DIR)/Globals_test.o
 
 OBJS_MEMORY_TEST =   $(OBJ_DIR)/Logger_test.o \
                   	 $(OBJ_DIR)/MemoryManager_test.o
@@ -293,7 +294,8 @@ OBJS_DIAGNOSTICSESSIONCONTROL_TEST = $(OBJ_DIR)/Logger_test.o \
 OBJS_SECURITYACCESS_TEST = $(OBJ_DIR)/Logger_test.o \
 						   $(OBJ_DIR)/GenerateFrames_test.o \
 			   			   $(OBJ_DIR)/SecurityAccess_test.o \
-			   			   $(OBJ_DIR)/NegativeResponse_test.o
+			   			   $(OBJ_DIR)/NegativeResponse_test.o \
+						   $(OBJ_DIR)/Globals_test.o
 
 OBJS_TESTERPRESENT_TEST = $(OBJ_DIR)/Logger_test.o \
 						  $(OBJ_DIR)/GenerateFrames_test.o \
@@ -352,6 +354,7 @@ OBJS_TRANSFERDATA_TEST = $(OBJ_DIR)/Logger_test.o \
 OBJS_NEGATIVERESPONSE_TEST = $(OBJ_DIR)/Logger_test.o \
                              $(OBJ_DIR)/GenerateFrames_test.o \
                              $(OBJ_DIR)/NegativeResponse_test.o \
+							 $(OBJ_DIR)/Globals_test.o
 
 OBJS_TEST = $(MCU_OBJS_TEST) \
             $(ECU_OBJS_TEST) \


### PR DESCRIPTION
## Description

Moving countDigits and to_lowercase from their respective classes to Globals caused several test executables to not build, as the Globals_test.o file was not linked to the executable.

⚠️ **Action requested**: Prioritize creating a CI job to build and run test executables
⚠️ Until we create a CI test job we should locally run `make allTests` to ensure this kind of errors do not occur again

make allTests works again

## Trello link [here](https://trello.com/c/okZ7ahWr/60-cannot-run-alltests)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
