### PR TITLE
fix: make ECU tests in allTests and clean ECU test files in both MCU and ECUs makefiles

### DIFF
--- a/ecu_simulation/BatteryModule/Makefile
+++ b/ecu_simulation/BatteryModule/Makefile
@@ -237,3 +237,9 @@ clean:
 	@echo "Cleaning up..."
 	rm -f $(FINAL)
 	rm -rf $(OBJ_DIR)
+	find ./test -name '*.gcno' -delete
+	find ./test -name '*.gcda' -delete
+	find ./test -name '*.gcov' -delete
+	find ./test -name '*.info' -delete
+	find ./test -name '*.out' -delete
+	find ./test -name '*.o' -delete

--- a/ecu_simulation/DoorsModule/Makefile
+++ b/ecu_simulation/DoorsModule/Makefile
@@ -237,3 +237,9 @@ clean:
 	@echo "Cleaning up..."
 	rm -f $(FINAL)
 	rm -rf $(OBJ_DIR)
+	find ./test -name '*.gcno' -delete
+	find ./test -name '*.gcda' -delete
+	find ./test -name '*.gcov' -delete
+	find ./test -name '*.info' -delete
+	find ./test -name '*.out' -delete
+	find ./test -name '*.o' -delete

--- a/ecu_simulation/EngineModule/Makefile
+++ b/ecu_simulation/EngineModule/Makefile
@@ -237,3 +237,9 @@ clean:
 	@echo "Cleaning up..."
 	rm -f $(FINAL)
 	rm -rf $(OBJ_DIR)
+	find ./test -name '*.gcno' -delete
+	find ./test -name '*.gcda' -delete
+	find ./test -name '*.gcov' -delete
+	find ./test -name '*.info' -delete
+	find ./test -name '*.out' -delete
+	find ./test -name '*.o' -delete

--- a/ecu_simulation/HVACModule/Makefile
+++ b/ecu_simulation/HVACModule/Makefile
@@ -233,3 +233,9 @@ clean:
 	@echo "Cleaning up..."
 	rm -f $(FINAL)
 	rm -rf $(OBJ_DIR)
+	find ./test -name '*.gcno' -delete
+	find ./test -name '*.gcda' -delete
+	find ./test -name '*.gcov' -delete
+	find ./test -name '*.info' -delete
+	find ./test -name '*.out' -delete
+	find ./test -name '*.o' -delete

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -456,7 +456,7 @@ $(OBJ_DIR)/NegativeResponse_test.o: $(UTILS_DIR)/NegativeResponse.cpp
 	
 # Compile all unit tests
 
-allTests: mcuModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils ecuTest
+allTests: mcuModuleTest batteryModuleTest engineModuleTest doorsModuleTest hvacModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils ecuTest
 
 
 # HandleFrames Unit tests
@@ -1302,10 +1302,10 @@ clean:
 			find $$dir -name '*.info' -delete; \
 		fi \
 	done
-	find . -name '*.gcno' -delete
-	find . -name '*.gcda' -delete
-	find . -name '*.gcov' -delete
-	find . -name '*.info' -delete
-	find ./test -name '*.out' -delete
-	find ./test -name '*.o' -delete
+	find .. -name '*.gcno' -delete
+	find .. -name '*.gcda' -delete
+	find .. -name '*.gcov' -delete
+	find .. -name '*.info' -delete
+	find .. -name '*.out' -delete
+	find .. -name '*.o' -delete
 	if [ -d "./coverage" ]; then find ./coverage -name '*' -delete; fi


### PR DESCRIPTION
## Description

`make allTests` did not build the ECU modules tests. Additionally, when running `make clean` from either the MCU makefile or the makefile of any ECU, the test related files were not removed.

I added these module tests at allTests in the MCU makefile. All ECU test and coverage related files are removed in the MCU makefile (for all ECUs) and in their respective makefile (for each ECU).

Tested on branch feature/fixMakeAllTests2 as make allTests is currently failing on development

## Trello link [here](https://trello.com/c/cJCHY47w/67-incomplete-test-building-and-cleaning-process)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
