### PR TITLE
Separate testing code from production code

### DIFF
--- a/ecu_simulation/BatteryModule/src/main.cpp
+++ b/ecu_simulation/BatteryModule/src/main.cpp
@@ -7,11 +7,7 @@
 
 int main() {
     loadProjectPathForECU();
-    #ifdef UNIT_TESTING_MODE
-    batteryModuleLogger = new Logger;
-    #else
     batteryModuleLogger = new Logger("batteryModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/BatteryModule/logs/batteryModuleLogger.log");
-    #endif /* UNIT_TESTING_MODE */
     battery = new BatteryModule();
     stopProcess("main_battery");
     std::thread receiveFrThread([]()

--- a/ecu_simulation/DoorsModule/src/main.cpp
+++ b/ecu_simulation/DoorsModule/src/main.cpp
@@ -7,11 +7,7 @@
 
 int main() {
     loadProjectPathForECU();
-    #ifdef UNIT_TESTING_MODE
-    doorsModuleLogger = new Logger;
-    #else
     doorsModuleLogger = new Logger("doorsModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/DoorsModule/logs/doorsModuleLogger.log");
-    #endif /* UNIT_TESTING_MODE */
     doors = new DoorsModule();
     stopProcess("main_doors");
     std::thread receiveFrThread([]()

--- a/ecu_simulation/EngineModule/src/main.cpp
+++ b/ecu_simulation/EngineModule/src/main.cpp
@@ -7,11 +7,7 @@
 
 int main() {
     loadProjectPathForECU();
-    #ifdef UNIT_TESTING_MODE
-    engineModuleLogger = new Logger;
-    #else
     engineModuleLogger = new Logger("engineModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/logs/engineModuleLogger.log");
-    #endif /* UNIT_TESTING_MODE */
     engine = new EngineModule();
     stopProcess("main_engine");
     std::thread receiveFrThread([]()

--- a/ecu_simulation/HVACModule/src/main.cpp
+++ b/ecu_simulation/HVACModule/src/main.cpp
@@ -8,11 +8,7 @@
 int main()
 {
     loadProjectPathForECU();
-    #ifdef UNIT_TESTING_MODE
-    hvacModuleLogger = new Logger;
-    #else
     hvacModuleLogger = new Logger("hvacModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/HVACModule/logs/hvacModuleLogger.log");
-    #endif
 
     hvac = new HVACModule();
     stopProcess("main_hvac");

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -277,6 +277,7 @@ UDS_OBJS_TEST = $(OBJ_DIR)/DiagnosticSessionControl_test.o \
                 $(OBJ_DIR)/ReadDataByIdentifier_test.o \
                 $(OBJ_DIR)/WriteDataByIdentifier_test.o \
                 $(OBJ_DIR)/EcuReset_test.o \
+				$(OBJ_DIR)/DummyEcuReset_test.o \
                 $(OBJ_DIR)/SecurityAccess_test.o \
                 $(OBJ_DIR)/TesterPresent_test.o \
                 $(OBJ_DIR)/ReadDtcInformation_test.o \
@@ -407,6 +408,9 @@ $(OBJ_DIR)/WriteDataByIdentifier_test.o: $(UDS_DIR)/write_data_by_identifier/src
 
 $(OBJ_DIR)/EcuReset_test.o: $(UDS_DIR)/ecu_reset/src/EcuReset.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/ecu_reset/src/EcuReset.cpp -o $(OBJ_DIR)/EcuReset_test.o $(CFLAGSTST2) $(LDFLAGS)
+
+$(OBJ_DIR)/DummyEcuReset_test.o: $(UDS_DIR)/ecu_reset/src/DummyEcuReset.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/ecu_reset/src/DummyEcuReset.cpp -o $(OBJ_DIR)/DummyEcuReset_test.o $(CFLAGSTST2) $(LDFLAGS)
 
 $(OBJ_DIR)/SecurityAccess_test.o: $(UDS_DIR)/authentication/src/SecurityAccess.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/authentication/src/SecurityAccess.cpp -o $(OBJ_DIR)/SecurityAccess_test.o $(CFLAGSTST2) $(LDFLAGS)

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -8,11 +8,7 @@
 int main() {
 
     loadProjectPathForMCU();
-    #ifndef UNIT_TESTING_MODE
     MCULogger = new Logger("MCULogger", std::string(PROJECT_PATH) + "/backend/mcu/logs/MCULogs.log");
-    #else
-    MCULogger = new Logger;
-    #endif /* UNIT_TESTING_MODE */
     MCU::mcu = new MCU::MCUModule(0x01);
     stopProcess("main_mcu");
     MCU::mcu->StartModule();

--- a/uds/ecu_reset/include/DummyEcuReset.h
+++ b/uds/ecu_reset/include/DummyEcuReset.h
@@ -1,0 +1,37 @@
+/**
+ * @file DummyEcuReset.h
+ * @author Stefan Corneteanu
+ * @brief ECU Reset service Dummy class.
+ * To be used in unit tests instead of the actual EcuReset
+ */
+
+#ifndef DUMMY_ECU_RESET_H
+#define DUMMY_ECU_RESET_H
+
+#include <cstdint>
+
+#include "EcuReset.h"
+#include "Logger.h"
+
+class DummyEcuReset : public EcuReset {
+public:
+    /**
+     * @brief Parameterized constructor.
+     * 
+     * @param can_id CAN identifier
+     * @param sub_function Subfunction for ECU Reset
+     * @param socket Socket to be used for response
+     * @param logger The logger
+     * @see EcuReset ctor
+     */
+    DummyEcuReset(uint32_t can_id, uint8_t sub_function, int socket, Logger &logger);
+
+    /**
+     * @brief Default dtor
+     */
+    ~DummyEcuReset() = default;
+
+    void hardReset() override;
+};
+
+#endif /* DUMMY_ECU_RESET_H */

--- a/uds/ecu_reset/include/EcuReset.h
+++ b/uds/ecu_reset/include/EcuReset.h
@@ -15,7 +15,7 @@
 
 class EcuReset
 {
-private:
+protected:
     uint32_t can_id;
     uint8_t sub_function;
     int socket = -1;
@@ -36,7 +36,7 @@ public:
      * @brief Destroy the Ecu Reset object
      * 
      */
-    ~EcuReset();
+    virtual ~EcuReset();
     /**
      * @brief Method that checks the subfunction and calls either hardReset() or keyOffReset().
      * data A vector containing the data bytes to be processed.
@@ -47,7 +47,7 @@ public:
      * @brief Method that does the Hard Reset.
      * 
      */
-    void hardReset();
+    virtual void hardReset();
 
     /**
      * @brief Method that does the Key Off Reset.

--- a/uds/ecu_reset/src/DummyEcuReset.cpp
+++ b/uds/ecu_reset/src/DummyEcuReset.cpp
@@ -1,0 +1,23 @@
+#include "EcuReset.h"
+#include "DummyEcuReset.h"
+#include "Logger.h"
+
+#include <cstdint>
+
+DummyEcuReset::DummyEcuReset(uint32_t can_id, uint8_t sub_function, int socket, Logger &logger)
+    : EcuReset(can_id, sub_function, socket, logger) {}
+
+void DummyEcuReset::hardReset(){
+    uint8_t lowerbits = can_id & 0xFF;
+    /* Send response */
+    this->ecuResetResponse();
+    /* During tests we do not want to actually hard reset the MCU/ECU. We will only check
+       if the lower bits match the MCU/ECU id. If not, log an error */
+    if (lowerbits != 0x10
+    && lowerbits != 0x11
+    && lowerbits != 0x12
+    && lowerbits != 0x13
+    && lowerbits != 0x14) {
+        LOG_ERROR(ECUResetLog.GET_LOGGER(), "ECU doesn't exist in hardReset");
+    }
+}

--- a/uds/ecu_reset/src/EcuReset.cpp
+++ b/uds/ecu_reset/src/EcuReset.cpp
@@ -77,57 +77,47 @@ void EcuReset::hardReset()
     {
         case 0x10:
         {   
-            #ifndef UNIT_TESTING_MODE
             const char *args[] = {"/bin/bash", "../autoscripts/reset_hard.sh", "main_mcu", NULL};
             execvp(args[0], const_cast<char *const *>(args));
 
             perror("execvp failed");
             exit(EXIT_FAILURE);
-            #endif
             break;
         }
         case 0x11:
         {
-            #ifndef UNIT_TESTING_MODE
             const char *args[] = {"/bin/bash", "../../autoscripts/reset_hard.sh", "main_battery", NULL};
             execvp(args[0], const_cast<char *const *>(args));
 
             perror("execvp failed");
             exit(EXIT_FAILURE);
-            #endif
             break;
         }
         case 0x12:
         {
-            #ifndef UNIT_TESTING_MODE
             const char *args[] = {"/bin/bash", "../../autoscripts/reset_hard.sh", "main_engine", NULL};
             execvp(args[0], const_cast<char *const *>(args));
 
             perror("execvp failed");
             exit(EXIT_FAILURE);
-            #endif
             break;
         }
         case 0x13:
         {
-            #ifndef UNIT_TESTING_MODE
             const char *args[] = {"/bin/bash", "../../autoscripts/reset_hard.sh", "main_doors", NULL};
             execvp(args[0], const_cast<char *const *>(args));
 
             perror("execvp failed");
             exit(EXIT_FAILURE);
-            #endif
             break;
         }
         case 0x14:
         {
-            #ifndef UNIT_TESTING_MODE
             const char *args[] = {"/bin/bash", "../../autoscripts/reset_hard.sh", "main_hvac", NULL};
             execvp(args[0], const_cast<char *const *>(args));
 
             perror("execvp failed");
             exit(EXIT_FAILURE);
-            #endif
             break;
         }
         default:

--- a/uds/ecu_reset/utest/EcuResetTest.cpp
+++ b/uds/ecu_reset/utest/EcuResetTest.cpp
@@ -13,6 +13,7 @@
 #include <net/if.h>
 #include <sys/socket.h>
 #include "../include/EcuReset.h"
+#include "../include/DummyEcuReset.h"
 #include "../../authentication/include/SecurityAccess.h"
 #include "../../../utils/include/ReceiveFrames.h"
 #include "../../../utils/include/NegativeResponse.h"
@@ -127,17 +128,17 @@ struct EcuResetTest : testing::Test
 
 TEST_F(EcuResetTest, ConstructorInitializesFieldsCorrectly)
 {
-    std::unique_ptr<EcuReset> ecuReset;
+    std::unique_ptr<DummyEcuReset> ecuReset;
     EXPECT_NO_THROW(
     {
-        ecuReset = std::make_unique<EcuReset>(0xFA10, 0x01, socket2, *logger);
+        ecuReset = std::make_unique<DummyEcuReset>(0xFA10, 0x01, socket2, *logger);
     });
 }
 
 TEST_F(EcuResetTest, IncorrectMessageLength)
 {
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA10, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA10, 0x01, socket2, *logger);
     struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x11, NegativeResponse::IMLOIF});
     ecuReset->ecuResetRequest({0x01, 0x11});
     c1->capture();
@@ -148,7 +149,7 @@ TEST_F(EcuResetTest, IncorrectMessageLength)
 TEST_F(EcuResetTest, SubFunctionNotSupported)
 {
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA10, 0x03, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA10, 0x03, socket2, *logger);
     struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x11, NegativeResponse::SFNS});
     ecuReset->ecuResetRequest({0x02, 0x11,0x03});
     c1->capture();
@@ -159,7 +160,7 @@ TEST_F(EcuResetTest, SubFunctionNotSupported)
 TEST_F(EcuResetTest, MCUSecurity)
 {
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA10, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA10, 0x01, socket2, *logger);
     struct can_frame result_frame = createFrame(0x10FA, {0x03, 0x7F, 0x11, NegativeResponse::SAD});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -171,7 +172,7 @@ TEST_F(EcuResetTest, ECUSecurity)
 {
     /* Battery */
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA11, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA11, 0x01, socket2, *logger);
     struct can_frame result_frame = createFrame(0x11FA, {0x03, 0x7F, 0x11, NegativeResponse::SAD});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -179,7 +180,7 @@ TEST_F(EcuResetTest, ECUSecurity)
     delete ecuReset;
 
     /* Engine */
-    ecuReset = new EcuReset(0xFA12, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA12, 0x01, socket2, *logger);
     result_frame = createFrame(0x12FA, {0x03, 0x7F, 0x11, NegativeResponse::SAD});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -187,7 +188,7 @@ TEST_F(EcuResetTest, ECUSecurity)
     delete ecuReset;
 
     /* Doors */
-    ecuReset = new EcuReset(0xFA13, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA13, 0x01, socket2, *logger);
     result_frame = createFrame(0x13FA, {0x03, 0x7F, 0x11, NegativeResponse::SAD});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -195,7 +196,7 @@ TEST_F(EcuResetTest, ECUSecurity)
     delete ecuReset;
 
     /* HVAC */
-    ecuReset = new EcuReset(0xFA14, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA14, 0x01, socket2, *logger);
     result_frame = createFrame(0x14FA, {0x03, 0x7F, 0x11, NegativeResponse::SAD});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -229,7 +230,7 @@ TEST_F(EcuResetTest, HardResetMCU)
     security->securityAccess(0xFA10, data_frame);
     c1->capture();
 
-    ecuReset = new EcuReset(0xFA10, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA10, 0x01, socket2, *logger);
     struct can_frame result_frame = createFrame(0x10FA, {0x02, 0x51,0x01});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -243,7 +244,7 @@ TEST_F(EcuResetTest, HardResetECU)
     EcuReset *ecuReset;
     ReceiveFrames* receiveFrames = new ReceiveFrames(socket2, 0x11, *logger);
     receiveFrames->setEcuState(true);
-    ecuReset = new EcuReset(0xFA11, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA11, 0x01, socket2, *logger);
     struct can_frame result_frame = createFrame(0x11FA, {0x02, 0x51,0x01});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -252,7 +253,7 @@ TEST_F(EcuResetTest, HardResetECU)
     delete receiveFrames;
 
     /* Engine */
-    ecuReset = new EcuReset(0xFA12, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA12, 0x01, socket2, *logger);
     result_frame = createFrame(0x12FA, {0x02, 0x51,0x01});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -260,7 +261,7 @@ TEST_F(EcuResetTest, HardResetECU)
     delete ecuReset;
 
     /* Doors */
-    ecuReset = new EcuReset(0xFA13, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA13, 0x01, socket2, *logger);
     result_frame = createFrame(0x13FA, {0x02, 0x51,0x01});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -268,7 +269,7 @@ TEST_F(EcuResetTest, HardResetECU)
     delete ecuReset;
 
     /* HVAC */
-    ecuReset = new EcuReset(0xFA14, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA14, 0x01, socket2, *logger);
     result_frame = createFrame(0x14FA, {0x02, 0x51,0x01});
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
@@ -276,7 +277,7 @@ TEST_F(EcuResetTest, HardResetECU)
     delete ecuReset;
 
     /* Other ECU */
-    ecuReset = new EcuReset(0xFA15, 0x01, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA15, 0x01, socket2, *logger);
     ecuReset->ecuResetRequest({0x02, 0x11,0x01});
     c1->capture();
     delete ecuReset;
@@ -285,7 +286,7 @@ TEST_F(EcuResetTest, HardResetECU)
 TEST_F(EcuResetTest, SoftResetMCU)
 {
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA10, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA10, 0x02, socket2, *logger);
     struct can_frame result_frame = createFrame(0x10FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();
@@ -297,7 +298,7 @@ TEST_F(EcuResetTest, SoftResetECU)
 {
     /* Battery */
     EcuReset *ecuReset;
-    ecuReset = new EcuReset(0xFA11, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA11, 0x02, socket2, *logger);
     struct can_frame result_frame = createFrame(0x11FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();
@@ -305,7 +306,7 @@ TEST_F(EcuResetTest, SoftResetECU)
     delete ecuReset;
 
     /* Engine */
-    ecuReset = new EcuReset(0xFA12, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA12, 0x02, socket2, *logger);
     result_frame = createFrame(0x12FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();
@@ -313,7 +314,7 @@ TEST_F(EcuResetTest, SoftResetECU)
     delete ecuReset;
 
     /* Doors */
-    ecuReset = new EcuReset(0xFA13, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA13, 0x02, socket2, *logger);
     result_frame = createFrame(0x13FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();
@@ -321,7 +322,7 @@ TEST_F(EcuResetTest, SoftResetECU)
     delete ecuReset;
 
     /* HVAC */
-    ecuReset = new EcuReset(0xFA14, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA14, 0x02, socket2, *logger);
     result_frame = createFrame(0x14FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();
@@ -329,7 +330,7 @@ TEST_F(EcuResetTest, SoftResetECU)
     delete ecuReset;
 
     /* Other ECU */
-    ecuReset = new EcuReset(0xFA15, 0x02, socket2, *logger);
+    ecuReset = new DummyEcuReset(0xFA15, 0x02, socket2, *logger);
     result_frame = createFrame(0x15FA, {0x02, 0x51,0x02});
     ecuReset->ecuResetRequest({0x02, 0x11, 0x02});
     c1->capture();


### PR DESCRIPTION
## Description

The following uses of the UNIT_TESTING_MODE preprocessor directive were removed with my changes:

1. Selection of default or parametrized Logger constructor inside the main functions for MCU and ECUs -> this is redundant as the console logger is used anyway during testing; only the parametrized Logger constructor will be used
2. Performing no actual resets in EcuReset::hardReset if we are in testing mode -> extracted the testing behavior in a dummy class

The following uses of the UNIT_TESTING_MODE preprocessor directive were NOT removed with my changes:

1. Changing the initially set DiagnosticSession inside DiagnosticSessionControl -> I considered extracting sessionControl in a standalone function but it uses class internals; I considered removing the UNKNOWN_SESSION altogether due to extremely low usage but it may be needed in the future; creating a mock only for this change felt unnecessary (to be deferred for when the creation of a MockDiagnosticSessionControl presents more value)
2. Changing the security timeout from security access -> I considered extracting sessionControl in a standalone function but it uses class internals; creating a mock only for this change felt unnecessary (to be deferred for when the creation of a MockSecurityAccess presents more value)
3. Selection of console logger or file logger -> intended to log to both console and file irrespective of testing/production mode; after private chat with @DirvaNIcolae dropped the idea as the console would be too full of logs and the important ones would be harder to track

## Trello link [here](https://trello.com/c/R1rW40Si/71-separate-test-code-from-production-code)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
