### PR TITLE
Provide ReadMemoryByAddressUTs, mocks for memorymanager and generateframes, and include gmock in makefile

### DIFF
--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -265,6 +265,8 @@ UTILS_OBJS_TEST = $(OBJ_DIR)/MemoryManager_test.o \
 
 OBJS_GENERATE_TEST = $(OBJ_DIR)/Logger_test.o \
                   	 $(OBJ_DIR)/GenerateFrames_test.o \
+					 $(OBJ_DIR)/NegativeResponse_test.o \
+					 $(OBJ_DIR)/SecurityAccess_test.o \
 					 $(OBJ_DIR)/Globals_test.o \
 					 $(OBJ_DIR)/TestUtils_test.o \
 					 $(OBJ_DIR)/CaptureFrame_test.o
@@ -360,6 +362,7 @@ OBJS_TRANSFERDATA_TEST = $(OBJ_DIR)/Logger_test.o \
 OBJS_NEGATIVERESPONSE_TEST = $(OBJ_DIR)/Logger_test.o \
                              $(OBJ_DIR)/GenerateFrames_test.o \
                              $(OBJ_DIR)/NegativeResponse_test.o \
+							 $(OBJ_DIR)/SecurityAccess_test.o \
 							 $(OBJ_DIR)/Globals_test.o \
 							 $(OBJ_DIR)/TestUtils_test.o \
 							 $(OBJ_DIR)/CaptureFrame_test.o

--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -45,7 +45,7 @@ LDFLAGS = -lspdlog -lfmt -lzip ${PYTHON_LDFLAGS}
 
 # Test flags
 CFLAGSTST = -std=c++17 -I/include -I/usr/include/python3.8 -fprofile-arcs -ftest-coverage
-CFLAGSTST2 = -lgtest -lgtest_main -lpthread
+CFLAGSTST2 = -lgmock -lgtest -lgtest_main -lpthread
 CFLAGSTST += -DUNIT_TESTING_MODE
 
 # Directories
@@ -476,7 +476,7 @@ $(OBJ_DIR)/NegativeResponse_test.o: $(UTILS_DIR)/NegativeResponse.cpp
 	
 # Compile all unit tests
 
-allTests: mcuModuleTest batteryModuleTest engineModuleTest doorsModuleTest hvacModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils ecuTest
+allTests: mcuModuleTest batteryModuleTest engineModuleTest doorsModuleTest hvacModuleTest handleFramesTest receiveFramesTest generateFramesTest loggerTest memoryManagerTest createInterfaceTest diagnosticSessionControlTest writeDataByIdentifierTest readDataByIdentifierTest requestTransferExitTest readDtcTest clearDtcTest requestUpdateStatusTest securityAccessTest testerPresentTest routineControlTest transferDataTest requestDownloadTest ecuResetTest negativeResponseTest accessTimingParameterTest receiveFramesTestUtils ecuTest readMemoryByAddressTest
 
 
 # HandleFrames Unit tests
@@ -589,6 +589,17 @@ $(UDS_DIR)/diagnostic_session_control/utest/diagnosticSessionControlTest.out: $(
 
 $(UDS_DIR)/diagnostic_session_control/utest/DiagnosticSessionControl_test.o: $(UDS_DIR)/diagnostic_session_control/utest/DiagnosticSessionControlTest.cpp
 	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/diagnostic_session_control/utest/DiagnosticSessionControlTest.cpp -o $(UDS_DIR)/diagnostic_session_control/utest/DiagnosticSessionControl_test.o $(CFLAGSTST2) $(LDFLAGS)
+
+
+
+# ReadMemoryByAddress Unit tests
+readMemoryByAddressTest: $(OBJ_DIR) $(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out
+
+$(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddress_test.o
+	$(CXX) $(CFLAGSTST) -o $(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddress_test.o $(OBJS_TEST) $(CFLAGSTST2) $(LDFLAGS)
+
+$(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddress_test.o: $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddressTest.cpp
+	$(CXX) $(CFLAGS) $(CFLAGSTST) -c $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddressTest.cpp -o $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddress_test.o $(CFLAGSTST2) $(LDFLAGS)
 
 
 
@@ -953,6 +964,21 @@ diagnosticSessionControl_coverage: diagnosticSessionControlTest
 
 
 
+# ReadMemoryByAddress Coverage - solo job
+readMemoryByAddressCoverage: readMemoryByAddress_coverage
+	lcov --capture --directory . --output-file coverage.info
+	lcov --remove coverage.info '/usr/' --output-file coverage_filtered.info
+	lcov --remove coverage.info '/test/' --output-file coverage.info
+	genhtml coverage_filtered.info --output-directory coverage/out_ReadMemoryByAddressTest
+	xdg-open coverage/out_ReadMemoryByAddressTest/index.html
+# This job runs for allCoverage
+readMemoryByAddress_coverage: readMemoryByAddressTest
+	./$(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out
+	mkdir -p coverage/out_ReadMemoryByAddress
+	gcov -o obj/ReadMemoryByAddress_test.gcno obj/ReadMemoryByAddress_test.gcda $(UDS_DIR)/read_memory_by_address/src/ReadMemoryByAddress.cpp
+	mv ReadMemoryByAddress.cpp.gcov coverage/out_ReadMemoryByAddress
+
+
 # CreateInterface Coverage - solo job
 createInterfaceCoverage: createInterface_coverage
 	lcov --capture --directory . --output-file coverage.info
@@ -1249,7 +1275,7 @@ batteryModule_coverage: batteryModuleTest
 
 
 
-allCoverage: securityAccess_coverage routineControl_coverage transferData_coverage requestDownload_coverage ecuReset_coverage memoryManager_coverage logger_coverage generateFrames_coverage mcuModule_coverage receiveFrames_coverage handleFrames_coverage createInterface_coverage diagnosticSessionControl_coverage writeDataByIdentifier_coverage readDataByIdentifier_coverage testerPresent_coverage requestTransferExit_coverage clearDtc_coverage readDtc_coverage requestUpdateStatus_coverage negativeResponse_coverage accessTimingParameter_coverage receiveFrames_coverage_utils ecu_coverage
+allCoverage: securityAccess_coverage routineControl_coverage transferData_coverage requestDownload_coverage ecuReset_coverage memoryManager_coverage logger_coverage generateFrames_coverage mcuModule_coverage receiveFrames_coverage handleFrames_coverage createInterface_coverage diagnosticSessionControl_coverage writeDataByIdentifier_coverage readDataByIdentifier_coverage testerPresent_coverage requestTransferExit_coverage clearDtc_coverage readDtc_coverage requestUpdateStatus_coverage negativeResponse_coverage accessTimingParameter_coverage receiveFrames_coverage_utils ecu_coverage readMemoryByAddress_coverage
 
 
 allCoveragePostProcess:

--- a/mcu/src/MCUModule.cpp
+++ b/mcu/src/MCUModule.cpp
@@ -286,7 +286,7 @@ namespace MCU
         memory_manager_instance->setPath(DEV_LOOP);
         memory_manager_instance->setAddress(DEV_LOOP_PARTITION_2_ADDRESS_END - (MCU_ID % 0x10) - 1);
 
-        uint8_t current_sw_version_from_memory = MemoryManager::readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (MCU_ID % 0x10) - 1 , 1, *MCULogger)[0];
+        uint8_t current_sw_version_from_memory = memory_manager_instance->readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (MCU_ID % 0x10) - 1 , 1, *MCULogger)[0];
         LOG_INFO(MCULogger->GET_LOGGER(), "Current software version from memory: {:x}", current_sw_version_from_memory);
         uint8_t current_sw_version_from_program = static_cast<uint8_t>(SOFTWARE_VERSION);
         LOG_INFO(MCULogger->GET_LOGGER(), "Current software_version {:x}", current_sw_version_from_program);
@@ -307,7 +307,7 @@ namespace MCU
         uint8_t previous_sw_version = 0;
         try
         {
-            previous_sw_version = MemoryManager::readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (MCU_ID % 0x10) - 1 , 1, *MCULogger)[0];
+            previous_sw_version = memory_manager_instance->readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (MCU_ID % 0x10) - 1 , 1, *MCULogger)[0];
             LOG_INFO(MCULogger->GET_LOGGER(), "Previous software version: {:x}", previous_sw_version);
         }
         catch(const std::runtime_error& e)

--- a/uds/read_memory_by_address/include/ReadMemoryByAddress.h
+++ b/uds/read_memory_by_address/include/ReadMemoryByAddress.h
@@ -12,12 +12,12 @@
 #define READ_MEMORY_BY_ADDRESS_H
 
 #include "Logger.h"
-#include "MemoryManager.h"
+#include "IMemoryManager.h"
 #include "GenerateFrames.h"
 
 class ReadMemoryByAddress {
 private:
-    MemoryManager* memoryManager;
+    IMemoryManager* memoryManager;
     GenerateFrames& frameGenerator;
     int socket;
     Logger& logger;
@@ -31,7 +31,7 @@ public:
      * @param socket Socket to send frames
      * @param log Instance of Logger
      */
-    ReadMemoryByAddress(MemoryManager* memManager, GenerateFrames& frameGen, int socket,  Logger& log);
+    ReadMemoryByAddress(IMemoryManager* memManager, GenerateFrames& frameGen, int socket,  Logger& log);
 
     /**
      * @brief Method to handle a Read Memory By Address request

--- a/uds/read_memory_by_address/src/ReadMemoryByAddress.cpp
+++ b/uds/read_memory_by_address/src/ReadMemoryByAddress.cpp
@@ -1,10 +1,11 @@
 #include <vector>
 
+#include "IMemoryManager.h"
 #include "ReadMemoryByAddress.h"
 #include "SecurityAccess.h"
 #include "NegativeResponse.h"
 
-ReadMemoryByAddress::ReadMemoryByAddress(MemoryManager* memManager, GenerateFrames& frameGen, int socket, Logger& log)
+ReadMemoryByAddress::ReadMemoryByAddress(IMemoryManager* memManager, GenerateFrames& frameGen, int socket, Logger& log)
     : memoryManager(memManager), frameGenerator(frameGen), socket(socket), logger(log) {}
 
 void ReadMemoryByAddress::handleRequest(int can_id, off_t memory_address, off_t memory_size) {
@@ -32,7 +33,7 @@ void ReadMemoryByAddress::handleRequest(int can_id, off_t memory_address, off_t 
     }
 
     /* Read data from memory */
-    std::vector<uint8_t> data = MemoryManager::readFromAddress(memoryManager->getPath(), memory_address, memory_size, logger);
+    std::vector<uint8_t> data = memoryManager->readFromAddress(memoryManager->getPath(), memory_address, memory_size, logger);
     
     if (data.empty()) {
         LOG_ERROR(logger.GET_LOGGER(), "Failed to read memory");

--- a/uds/read_memory_by_address/utest/ReadMemoryByAddressTest.cpp
+++ b/uds/read_memory_by_address/utest/ReadMemoryByAddressTest.cpp
@@ -1,0 +1,244 @@
+#include <cstdint>
+#include <gmock/gmock-cardinalities.h>
+#include <gmock/gmock-spec-builders.h>
+#include <gtest/gtest.h>
+#include <linux/can.h>
+#include <memory>
+#include <sys/types.h>
+#include <vector>
+
+#include "../include/ReadMemoryByAddress.h"
+#include "../../authentication/include/SecurityAccess.h"
+#include "../../../utils/include/CaptureFrame.h"
+#include "../../../utils/include/GenerateFrames.h"
+#include "../../../utils/include/Logger.h"
+#include "../../../utils/include/MemoryManager.h"
+#include "../../../utils/include/MockGenerateFrames.h"
+#include "../../../utils/include/MockMemoryManager.h"
+#include "../../../utils/include/NegativeResponse.h"
+#include "../../../utils/include/TestUtils.h"
+
+using namespace testing;
+
+const int kFrameId = 0x01;
+const int kCanId = 0x01;
+const int kVCanInterface = 0x01;
+
+struct ReadMemoryByAddressTest : Test {
+
+    ReadMemoryByAddressTest() {
+        socket = createSocket(kVCanInterface);
+        socket2 = createSocket(kVCanInterface);
+        spCapturedFrame = std::make_shared<CaptureFrame>(socket2);
+        pMockMemoryManager = new MockMemoryManager();
+        spMockGenerateFrames =  std::make_shared<MockGenerateFrames>(logger);
+        readMemoryByAddress = std::make_unique<ReadMemoryByAddress>(pMockMemoryManager, *spMockGenerateFrames, socket, logger);
+        spSecurityAccess = std::make_shared<SecurityAccess>(socket, logger);
+    }
+
+    ~ReadMemoryByAddressTest(){
+        delete pMockMemoryManager;
+        close(socket);
+    }
+
+    std::shared_ptr<CaptureFrame> spCapturedFrame;
+    std::shared_ptr<SecurityAccess> spSecurityAccess;
+    int socket, socket2;
+    Logger logger;
+    MockMemoryManager* pMockMemoryManager;
+    std::shared_ptr<MockGenerateFrames> spMockGenerateFrames;
+    std::unique_ptr<ReadMemoryByAddress> readMemoryByAddress;
+};
+
+TEST_F(ReadMemoryByAddressTest, InvalidMemoryAddress){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::IMLOIF});
+
+    // One call to availableAddress may occur
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).Times(AtMost(1)).WillOnce(Return(false));
+    // One call to availableMemory may occur
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).Times(AtMost(1)).WillOnce(Return(false));
+    // Do not expect calls from readFromAddress method
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_)).Times(0);
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    // Request with a negative (invalid) memory address)
+    readMemoryByAddress->handleRequest(kCanId, -1, 1);
+    spCapturedFrame->capture(); //IMLOIF from invalid memory address
+    testFrames(expectedFrame, *spCapturedFrame);
+    spCapturedFrame->capture(); //IMLOIF from unavailable memory address
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, InvalidMemorySize){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::IMLOIF});
+
+    // One call to availableAddress may occur
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).Times(AtMost(1)).WillOnce(Return(false));
+    // One call to availableMemory may occur
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).Times(AtMost(1)).WillOnce(Return(false));
+    // Do not expect calls from readFromAddress method
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_)).Times(0);
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    // Request with a negative (invalid) memory size)
+    readMemoryByAddress->handleRequest(kCanId, 1, -1);
+    spCapturedFrame->capture(); //IMLOIF from invalid memory size
+    testFrames(expectedFrame, *spCapturedFrame);
+    spCapturedFrame->capture(); //IMLOIF from unavailable memory size
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, UnavailableMemoryAddress){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::IMLOIF});
+
+    // Expect failure of availableAddress
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).Times(AtMost(1)).WillOnce(Return(false));
+    // One call to availableMemory may occur
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).Times(AtMost(1));
+    // Do not expect calls from readFromAddress method
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_)).Times(0);
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+    spCapturedFrame->capture();
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, UnavailableMemorySize){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::IMLOIF});
+
+    // Expect failure of availableMemory
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).Times(AtMost(1)).WillOnce(Return(false));
+    // One call to availableAddress may occur
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).Times(AtMost(1));
+    // Do not expect calls from readFromAddress method
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_)).Times(0);
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+    spCapturedFrame->capture();
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, SecurityAccessDenied){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::SAD});
+
+    // Expect pass of both availableAddress availableMemory
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).WillOnce(Return(true));
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).WillOnce(Return(true));
+    // Do not expect calls from readFromAddress method
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_)).Times(0);
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    // handleRequest will return as mcu_state is false
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+    spCapturedFrame->capture();
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, ReadMemoryFailure){
+    struct can_frame expectedFrame = createFrame(kFrameId, {0x03, 0x7F, 0x23, NegativeResponse::ROOR});
+
+    // Expect pass of both availableAddress availableMemory
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).WillOnce(Return(true));
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).WillOnce(Return(true));
+    // Expect call of readFromAddress, return nothing leading to read memory failure
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_))
+    .WillOnce(Return(std::vector<uint8_t>{}));
+    // readFromAddress will call getPath
+    EXPECT_CALL(*pMockMemoryManager, getPath());
+
+    // Expect no calls from mock generate frames
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    // grant security access
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, 0x23);
+
+    // handleRequest will return due to failure to read
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+    spCapturedFrame->capture(); // This capture will get the frame generated by securityAccessSendKey
+    spCapturedFrame->capture(); // This capture will get the Negative Response frame
+    testFrames(expectedFrame, *spCapturedFrame);
+}
+
+TEST_F(ReadMemoryByAddressTest, Response){
+    auto expectedResponse = std::vector<uint8_t>{0x01,0x02,0x03};
+    // Expect pass of both availableAddress availableMemory
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).WillOnce(Return(true));
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).WillOnce(Return(true));
+    // Expect call of readFromAddress, return less than 6 bytes leading to normal response
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_))
+    .WillOnce(Return(expectedResponse));
+    // readFromAddress will call getPath
+    EXPECT_CALL(*pMockMemoryManager, getPath());
+
+    // Expect a call from readMemoryByAddress
+    EXPECT_CALL(*spMockGenerateFrames, 
+        readMemoryByAddress(
+            kCanId, 1, 1, expectedResponse
+        )
+    );
+    // Expect no long response
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddressLongResponse(_,_,_,_,_)).Times(0);
+
+    // grant security access
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, 0x23);
+
+    // handleRequest will lead to normal response
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+}
+
+TEST_F(ReadMemoryByAddressTest, LongResponse){
+    auto expectedResponse = std::vector<uint8_t>{0x01,0x02,0x03,0x04,0x05,0x06, 0x07};
+    // Expect pass of both availableAddress availableMemory
+    EXPECT_CALL(*pMockMemoryManager, availableAddress).WillOnce(Return(true));
+    EXPECT_CALL(*pMockMemoryManager, availableMemory).WillOnce(Return(true));
+    // Expect call of readFromAddress, return less than 6 bytes leading to long response
+    EXPECT_CALL(*pMockMemoryManager, readFromAddress(_,_,_,_))
+    .WillOnce(Return(expectedResponse));
+    // readFromAddress will call getPath
+    EXPECT_CALL(*pMockMemoryManager, getPath());
+
+    // Expect no normal response
+    EXPECT_CALL(*spMockGenerateFrames, readMemoryByAddress(_,_,_,_)).Times(0);
+    // Expect 2 calls to normal response
+    InSequence longResponseCallsSequence;
+    EXPECT_CALL(*spMockGenerateFrames, 
+        readMemoryByAddressLongResponse(
+            kCanId, 1, 1, expectedResponse, true
+        )
+    );
+    EXPECT_CALL(*spMockGenerateFrames, 
+        readMemoryByAddressLongResponse(
+            kCanId, 1, 1, expectedResponse, false
+        )
+    );
+
+    // grant security access
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, 0x23);
+
+    // handleRequest will lead to long response
+    readMemoryByAddress->handleRequest(kCanId, 1, 1);
+}
+
+int main(int argc, char **argv)
+{
+testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/utils/include/GenerateFrames.h
+++ b/utils/include/GenerateFrames.h
@@ -38,6 +38,12 @@ class GenerateFrames
          * @param logger A logger instance used to record information and errors during the execution.
          */
         GenerateFrames(int socket, Logger& logger);
+
+        /**
+         * @brief Default destructor
+         */
+        virtual ~GenerateFrames() = default;
+
         /**
          * @brief Method to get the socket
          * 
@@ -191,7 +197,7 @@ class GenerateFrames
          * @param response variable for request or response frame
          * Response&Request
          */
-        void readMemoryByAddress(int id, int memory_address, int memory_size, std::vector<uint8_t> response = {});
+        virtual void readMemoryByAddress(int id, int memory_address, int memory_size, std::vector<uint8_t> response = {});
         /**
          * @brief Frame for Read data by Address. Check the commentary from the readDataByIdentifier() method
          * 
@@ -201,7 +207,7 @@ class GenerateFrames
          * @param response variable for request or response frame
          * @param first_frame set as true if it is the first frame (default) or false for the rest of the frames.
          */
-        void readMemoryByAddressLongResponse(int id, int memory_address, int memory_size, std::vector<uint8_t> response, bool first_frame = true);
+        virtual void readMemoryByAddressLongResponse(int id, int memory_address, int memory_size, std::vector<uint8_t> response, bool first_frame = true);
         /**
          * @brief Frame for Write data by Identifier. Check the commentary from the readDataByIdentifier() method
          * 

--- a/utils/include/IMemoryManager.h
+++ b/utils/include/IMemoryManager.h
@@ -1,0 +1,54 @@
+/**
+ * @brief Interface of memory manager
+ * @author Stefan Corneteanu
+ * @date 2025-02-07
+ *
+ * @copyright (c) 2025
+ */
+
+#ifndef IMEMORY_MANAGER_H
+#define IMEMORY_MANAGER_H
+
+#include <cstdint>
+#include <string>
+#include <sys/types.h>
+#include <vector>
+
+#include "Logger.h"
+
+class IMemoryManager{
+public:
+
+    /** 
+     * @brief Default dtor
+     */
+    virtual ~IMemoryManager() = default;
+    /** 
+     * @brief Call to see if address is available
+     * @param address The checked address
+     * @return Availability of address
+     */
+    virtual bool availableAddress(off_t address) = 0;
+    /** 
+     * @brief Call to see if memory size is available
+     * @param size_of_data The size of the memory checked
+     * @return Availability of memory size
+     */
+    virtual bool availableMemory(off_t size_of_data) = 0;
+    /** 
+     * @brief Call to read from address
+     * @param path Path from which data is read
+     * @param address_start The address from which data is read
+     * @param size The size of data to be read
+     * @param logger a logger that logs necessary data to console/file
+     * @return The data at address
+     */
+    virtual std::vector<uint8_t> readFromAddress(std::string path, off_t address_start, off_t size, Logger& logger) = 0;
+    /** 
+     * @brief Call to get the memory manager's path
+     * @return The path
+     */
+    virtual std::string getPath() = 0;
+};
+
+#endif

--- a/utils/include/MemoryManager.h
+++ b/utils/include/MemoryManager.h
@@ -63,7 +63,7 @@
         install2->writeToAddress(data);
 
         // line called to move from adress to the executable(Can be implemented in a routine) 
-        std::vector<uint8_t> data2 = MemoryManager::readFromAddress("/dev/loop21", install2->getAddress(), data.size()); //Read from the address
+        std::vector<uint8_t> data2 = install->readFromAddress("/dev/loop21", install2->getAddress(), data.size()); //Read from the address
         MemoryManager::writeToFile(data2, "/mnt/sdcard/test"); //Write in bin the data
     }
     */
@@ -74,6 +74,7 @@
 #include <cstring>
 #include <vector>
 
+#include "IMemoryManager.h"
 #include "Logger.h"
 
 #define DEV_LOOP "/dev/loop0"
@@ -89,7 +90,7 @@
 #define DEV_LOOP_PARTITION_2_ADDRESS_END 614399
 #define DEV_LOOP_PARTITION_2_SECTORS ((DEV_LOOP_PARTITION_2_ADDRESS_END - DEV_LOOP_PARTITION_2_ADDRESS_START) + 1)
 #define DEV_LOOP_PARTITION_2_SIZE (DEV_LOOP_PARTITION_2_SECTORS * SECTOR_SIZE)
-class MemoryManager
+class MemoryManager : public IMemoryManager
 {
     private:
         std::string path;
@@ -117,7 +118,12 @@ class MemoryManager
          * @param logger 
          */
         MemoryManager(off_t address, std::string path, Logger& logger);
-        
+
+        /**
+         * @brief Default destructor
+         */
+        ~MemoryManager() override = default;
+
         /**
          * @brief Get the Instance object
          * 
@@ -169,7 +175,7 @@ class MemoryManager
          * 
          * @return std::string 
          */
-        std::string getPath();
+        std::string getPath() override;
 
         /**
          * @brief Method to read a binary file. This is a static method.
@@ -186,7 +192,7 @@ class MemoryManager
          * @param address 
          * @return true or false
          */
-        bool availableAddress(off_t address);
+        bool availableAddress(off_t address) override;
 
         /**
          * @brief Method to check if the amount of memory is available
@@ -194,10 +200,10 @@ class MemoryManager
          * @param size_of_data 
          * @return true or false
          */
-        bool availableMemory(off_t size_of_data);
+        bool availableMemory(off_t size_of_data) override;
         
         /**
-         * @brief Method to read from an address. This is a static method.
+         * @brief Method to read from an address.
          * 
          * @param path Path to a sd, usb, etc
          * @param address_start Start address
@@ -205,7 +211,7 @@ class MemoryManager
          * @param logger
          * @return std::vector<uint8_t> 
          */
-        static std::vector<uint8_t> readFromAddress(std::string path, off_t address_start, off_t size, Logger& logger);
+        std::vector<uint8_t> readFromAddress(std::string path, off_t address_start, off_t size, Logger& logger) override;
 
         /**
          * @brief Method to write data in a specific address. This method uses the address specified in the constructor.

--- a/utils/include/MockGenerateFrames.h
+++ b/utils/include/MockGenerateFrames.h
@@ -1,0 +1,36 @@
+/**
+ * @brief Pure mock class of GenerateFrames to be used in unit tests
+ * @author Stefan Corneteanu
+ * @date 2025-02-07
+ *
+ * @copyright (c) 2025
+ */
+
+#ifndef MOCK_GENERATE_FRAMES_H
+#define MOCK_GENERATE_FRAMES_H
+
+#include <gmock/gmock-function-mocker.h>
+#include <gmock/gmock.h>
+
+#include "GenerateFrames.h"
+#include "Logger.h"
+
+class MockGenerateFrames: public GenerateFrames {
+public:
+
+    /**
+     * @brief Super ctor
+     */
+    MockGenerateFrames(Logger &logger)
+    : GenerateFrames(logger) {}
+
+    /**
+     * @brief Default dtor
+     */
+    ~MockGenerateFrames() override = default;
+
+    MOCK_METHOD(void, readMemoryByAddress, (int id, int memory_address, int memory_size, std::vector<uint8_t> response));
+    MOCK_METHOD(void, readMemoryByAddressLongResponse, (int id, int memory_address, int memory_size, std::vector<uint8_t> response, bool first_frame));
+};
+
+#endif

--- a/utils/include/MockMemoryManager.h
+++ b/utils/include/MockMemoryManager.h
@@ -1,0 +1,32 @@
+/**
+ * @brief Pure mock class of memory manager to be used in unit tests
+ * @author Stefan Corneteanu
+ * @date 2025-02-06
+ *
+ * @copyright (c) 2025
+ */
+
+#ifndef MOCK_MEMORY_MANAGER_H
+#define MOCK_MEMORY_MANAGER_H
+
+#include <cstdint>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gmock/gmock-function-mocker.h>
+#include <sys/types.h>
+
+#include "Logger.h"
+#include "IMemoryManager.h"
+
+class MockMemoryManager : public IMemoryManager {
+public:
+
+    ~MockMemoryManager() override = default;
+    MOCK_METHOD(bool, availableAddress, (off_t address));
+    MOCK_METHOD(bool, availableMemory, (off_t size_of_data));
+    MOCK_METHOD(std::vector<uint8_t>, readFromAddress, (std::string path, off_t address_start, off_t size, Logger& logger));
+    MOCK_METHOD(std::string, getPath, ());
+};
+
+#endif

--- a/utils/include/TestUtils.h
+++ b/utils/include/TestUtils.h
@@ -60,6 +60,11 @@ struct can_frame createFrame(int id, std::vector<uint8_t> data, FrameType frameT
 /**
  * @brief Create the socket
  * 
+ * @warning Before running tests containing this function, do the following:
+ * 1) sudo modprobe vcan (loads the virtual can kernel module)
+ * 2) sudo ip link add type vcan name vcan<interface_number> (@see @param interface_number)
+ * 3) ip link show(verify interfaces, make sure that vcan<interface_number> is listed)
+ * 4) sudo ip link set vcan<interface_number> up (set up the interface before communication)
  * @param interface_number The interface indicator number.
  * @return Returns the socket file descriptor.
  */

--- a/utils/include/TestUtils.h
+++ b/utils/include/TestUtils.h
@@ -12,11 +12,13 @@
 
 #include <cstdint>
 #include <linux/can.h>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "CaptureFrame.h"
 #include "Globals.h"
+#include "../../uds/authentication/include/SecurityAccess.h"
 
 /**
  * @brief Check if a line is inside of an output
@@ -70,4 +72,11 @@ struct can_frame createFrame(int id, std::vector<uint8_t> data, FrameType frameT
  */
 int createSocket(uint8_t interface_number);
 
+/**
+ * @brief request security access 
+ * @param securityAccess a security access object used for requesting the seed
+ * @param capturedFrame a capture frame object used to capture the security access seed
+ * @param sid the id of the service for which we request access
+ */
+void v_requestSecurityAccess(std::shared_ptr<SecurityAccess> spSecurityAccess, std::shared_ptr<CaptureFrame> spCapturedFrame, uint8_t sid);
 #endif

--- a/utils/src/ECU.cpp
+++ b/utils/src/ECU.cpp
@@ -77,7 +77,7 @@ void ECU::checkSwVersion()
     uint8_t previous_sw_version = 0;
     try
     {
-        previous_sw_version = MemoryManager::readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (_module_id % 0x10) - 1, 1, _logger)[0];
+        previous_sw_version = memory_manager_instance->readFromAddress(DEV_LOOP, DEV_LOOP_PARTITION_2_ADDRESS_END - (_module_id % 0x10) - 1, 1, _logger)[0];
     }
     catch(const std::runtime_error& e)
     {

--- a/utils/src/TestUtils.cpp
+++ b/utils/src/TestUtils.cpp
@@ -1,6 +1,6 @@
 #include <cstdint>
+#include <cstring>
 #include <fcntl.h>
-#include <iostream>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -77,7 +77,7 @@ int createSocket(uint8_t interface_number) {
     s = socket(PF_CAN, SOCK_RAW, CAN_RAW);
     if (s < 0)
     {
-        std::cout<<"Error trying to create the socket\n";
+        perror("Error trying to create the socket");
         return 1;
     }
     /* Giving name and index to the interface created */
@@ -90,7 +90,7 @@ int createSocket(uint8_t interface_number) {
     int b = bind(s, (struct sockaddr*)&addr, sizeof(addr));
     if( b < 0 )
     {
-        std::cout<<"Error binding\n";
+        perror("Error binding");
         return 1;
     }
     int flags = fcntl(s, F_GETFL, 0);


### PR DESCRIPTION
## Description

The following changes are provided in this PR:

1. Implementation of a mock MemoryManager: In order to achieve this, I turned the readMemoryAddress static method into a member method. Along with availableAddress, availableMemory and getPath, these methods were extracted into a new IMemoryManager interface, extended by both MemoryManager and the newly created mock. This IMemoryManager interface replaces the MemoryManager in the ReadMemoryFromAddress' constructor. The aforementioned methods are used in the ReadMemoryByAddressUTs (see 4.), but the interface and the mock are open to adding new methods
2. Implementation of a mock GenerateFrames: the readMemoryByAddress and readMemoryByAddressLongResponse were made virtual, implemented in the mock, used in the ReadMemoryByAddressUTs (see 4.), but the mock is open to adding new methods. I decided to use a mock to prevent having to deal with potential issues thrown by GenerateFrames.
3. Added the the gmock library flag in the MCU Makefile's test flags. Useful not only for my mocks but also its inclusion in RequestUpdateStatusTest suggests that this addition is intended. Nonetheless, it is highly encouraged to work with mocks provided by such libraries
4. Provided the 8 unit tests for ReadMemoryByAddress: The cases dealt with are as follows: invalid memory address/size, unavailable memory address/size, security access denied, read memory failure, response and long response. All unit tests pass (after providing the bugfix at 5.) and coverage is 100% (see the Trello ticket for images).
5. Unrelated but helpful, I modified the createSocket from TestUtils to better print the error messages, and I provided the necessary documentation for preconditions on how to run unit tests relying on createSocket (setting up the vcan interfaces)
6. An additional utility requestSecurityAccess function was added in TestUtils. Initially it was a method of ReadMemoryByAddressTest, however it was extracted as it is deemed useful for [this ticket](https://trello.com/c/vyZDWiJG/41-rework-tests-for-request-download)

All unit tests for the ReadMemoryByAddress test suite pass and coverage is 100% (see the Trello ticket for images)
TODO: update the backend coverage status after merge

## Trello link [here](https://trello.com/c/AS8kSYgm/46-create-tests-for-read-memory-by-address)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
