### PR TITLE
refactor: rework loadProjectPath to be independent of current working directory

### DIFF
--- a/ecu_simulation/BatteryModule/src/main.cpp
+++ b/ecu_simulation/BatteryModule/src/main.cpp
@@ -6,7 +6,7 @@
 #include "Globals.h"
 
 int main() {
-    loadProjectPathForECU();
+    v_loadProjectPath();
     batteryModuleLogger = new Logger("batteryModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/BatteryModule/logs/batteryModuleLogger.log");
     battery = new BatteryModule();
     stopProcess("main_battery");

--- a/ecu_simulation/DoorsModule/src/main.cpp
+++ b/ecu_simulation/DoorsModule/src/main.cpp
@@ -6,7 +6,7 @@
 #include "Globals.h"
 
 int main() {
-    loadProjectPathForECU();
+    v_loadProjectPath();
     doorsModuleLogger = new Logger("doorsModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/DoorsModule/logs/doorsModuleLogger.log");
     doors = new DoorsModule();
     stopProcess("main_doors");

--- a/ecu_simulation/EngineModule/src/main.cpp
+++ b/ecu_simulation/EngineModule/src/main.cpp
@@ -6,7 +6,7 @@
 #include "Globals.h"
 
 int main() {
-    loadProjectPathForECU();
+    v_loadProjectPath();
     engineModuleLogger = new Logger("engineModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/logs/engineModuleLogger.log");
     engine = new EngineModule();
     stopProcess("main_engine");

--- a/ecu_simulation/HVACModule/src/main.cpp
+++ b/ecu_simulation/HVACModule/src/main.cpp
@@ -7,7 +7,7 @@
 
 int main()
 {
-    loadProjectPathForECU();
+    v_loadProjectPath();
     hvacModuleLogger = new Logger("hvacModuleLogger", std::string(PROJECT_PATH) + "/backend/ecu_simulation/HVACModule/logs/hvacModuleLogger.log");
 
     hvac = new HVACModule();

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -7,7 +7,7 @@
 
 int main() {
 
-    loadProjectPathForMCU();
+    v_loadProjectPath();
     MCULogger = new Logger("MCULogger", std::string(PROJECT_PATH) + "/backend/mcu/logs/MCULogs.log");
     MCU::mcu = new MCU::MCUModule(0x01);
     stopProcess("main_mcu");

--- a/mcu/test/MCUModuleTest.cpp
+++ b/mcu/test/MCUModuleTest.cpp
@@ -47,7 +47,7 @@ protected:
     MCUModuleTest()
     {
         mockLogger = new Logger;
-        loadProjectPathForMCU();
+        v_loadProjectPath();
     }
     ~MCUModuleTest()
     {

--- a/mcu/test/ReceiveFramesTest.cpp
+++ b/mcu/test/ReceiveFramesTest.cpp
@@ -59,7 +59,7 @@ protected:
     /* Setup method to initialize test environment */
     virtual void SetUp()
     {
-        loadProjectPathForMCU();
+        v_loadProjectPath();
         /* Create mock socket pairs for testing */
         socketpair(AF_UNIX, SOCK_STREAM, 0, mock_socket_pair_canbus);
         socketpair(AF_UNIX, SOCK_STREAM, 0, mock_socket_pair_api);

--- a/utils/include/Globals.h
+++ b/utils/include/Globals.h
@@ -6,8 +6,10 @@
 
 extern std::string PROJECT_PATH;
 
-void loadProjectPathForMCU();
-void loadProjectPathForECU();
+/**
+ * @brief find the config.ini file and load project path from it
+ */
+void v_loadProjectPath();
 
 /**
  * @brief Convert all the letters to lowercase

--- a/utils/src/Globals.cpp
+++ b/utils/src/Globals.cpp
@@ -1,29 +1,25 @@
 #include "Globals.h"
+#include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <algorithm>
+#include <string>
 
 std::string PROJECT_PATH;
 
-void loadProjectPathForMCU() {
-    std::ifstream file("../config/config.ini");
-    if (!file.is_open()) {
-        throw std::runtime_error("Could not open config.ini");
+void v_loadProjectPath() {
+    std::filesystem::path configIniFilePath = std::filesystem::current_path().remove_filename();
+    while (!configIniFilePath.empty() && configIniFilePath.filename().string() != std::string("backend")){
+        configIniFilePath = configIniFilePath.parent_path();
     }
 
-    std::string line, key = "PROJECT_PATH=";
-    while (std::getline(file, line)) {
-        if (line.rfind(key, 0) == 0) {
-            PROJECT_PATH = line.substr(key.size());
-            return;
-        }
+    // Sanity check, ensure that backend was found
+    if (configIniFilePath.empty()){
+        throw std::runtime_error("Root directory reached when loading project path. Check that this function was called from a file inside Poc/src/backend or any of its subdirectories");
     }
 
-    throw std::runtime_error("PROJECT_PATH not found in config.ini");
-}
-
-void loadProjectPathForECU() {
-    std::ifstream file("../../config/config.ini");
+    configIniFilePath /= "config/config.ini";
+    std::ifstream file(configIniFilePath.c_str());
     if (!file.is_open()) {
         throw std::runtime_error("Could not open config.ini");
     }


### PR DESCRIPTION
## Description

Currently there are 2 loadProjectPath functions, one for MCU and one for ECU. They use paths relative to the current working directory, which may cause issues when running an executable from another directory other than the source file's path. This PR aims to use a single loadProjectPath that works irrespective of the current working directory by repeatedly looking in the current filepath if the last directory is "backend" and the appending to it "config/config.ini". The new implementation replaces loadProjectPathForMCU/ECU

Tested by running main_mcu and main_battery with my changes

## Trello link [here](put here the link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
