### PR TITLE
test: fix failing UT and add extra logging

### DIFF
--- a/ecu_simulation/EngineModule/src/EngineModule.cpp
+++ b/ecu_simulation/EngineModule/src/EngineModule.cpp
@@ -71,7 +71,7 @@ EngineModule::~EngineModule()
 void EngineModule::fetchEngineData()
 {
     /* Path to engine data file */
-    std::string strFilePath = "engine_data.txt";
+    std::string strFilePath = std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/engine_data.txt";
 
     /* Generate random values for each DID */
     std::unordered_map<uint16_t, std::string> updated_values;
@@ -158,7 +158,7 @@ void EngineModule::writeDataToFile()
     }
 
     /* Check if old_engine_data.txt exists */
-    std::string strOldFilePath = "old_engine_data.txt";
+    std::string strOldFilePath = std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/old_engine_data.txt";
     std::ifstream ifs_Infile(strOldFilePath);
 
     if (ifs_Infile.is_open())
@@ -226,6 +226,7 @@ void EngineModule::checkDTC()
     }
     else
     {
+        LOG_ERROR(engineModuleLogger->GET_LOGGER(), "Failed to create dtcs.txt file.");
         ifs_Infile.close();
     }
     /* Read the map with DIDs from the file */

--- a/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
+++ b/ecu_simulation/EngineModule/test/EngineModuleTest.cpp
@@ -9,6 +9,7 @@ struct EngineModuleTest : testing::Test
     EngineModule* engine;
     EngineModuleTest()
     {
+        v_loadProjectPath();
         engine = new EngineModule();
     }
     ~EngineModuleTest()
@@ -26,7 +27,7 @@ TEST_F(EngineModuleTest, EngineSocket)
 
 TEST_F(EngineModuleTest, CheckOldDataFile)
 {
-    std::ofstream outfile("old_engine_data.txt");
+    std::ofstream outfile(std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/old_engine_data.txt");
     engine->writeDataToFile();
     outfile.close();
 }
@@ -60,14 +61,14 @@ TEST_F(EngineModuleTest, checkDTCCreateFileSuccessfully)
 
 TEST_F(EngineModuleTest, BatteryDataFailed)
 {
-    std::string path = "engine_data.txt";
+    std::string path = std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/engine_data.txt";
     std::ofstream outfile(path);
     chmod(path.c_str(), 0);
     EXPECT_THROW(
     {
         engine->writeDataToFile();
     }, std::runtime_error);
-    path = "engine_data.txt";
+    path = std::string(PROJECT_PATH) + "/backend/ecu_simulation/EngineModule/engine_data.txt";
     chmod(path.c_str(), 0666);
     outfile.close();
 }


### PR DESCRIPTION
## Description

EngineModuleTest::checkDTCCreateFileSuccessfully failed as it could not open the dtcs.txt file. This was because the project path was not yet loaded. Fixed by adding a call to loadProjectPath in the test suite constructor. Additionally, a new log is added for when we fail to open a file input stream to dtcs.txt. For coverage purpose, the path to engine_data and old_engine_data was updated to be dependant on the PROJECT_PATH
All tests pass and 100% coverage achieved

## Trello link [here](https://trello.com/c/AFLL20aW/44-investigate-enginemoduletests)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
