### PR TITLE
Error API Ota  fix

### DIFF
--- a/ota/google_drive_api/GoogleDriveApi.py
+++ b/ota/google_drive_api/GoogleDriveApi.py
@@ -203,6 +203,40 @@ class GDriveAPI:
                                          for file in folder_data['files'])
 
         return json_file
+    
+    def getDriveData_from_ECU(self, file):
+
+        json_files = {"versions": []}
+        folder_data = None
+
+        if file == 'MCU':
+            folder_data = self.__getFilesFromFolder(DRIVE_MCU_SW_VERSIONS_FILE)
+        elif file == "ECUBATTERY":
+            folder_data = self.__getFilesFromFolder(DRIVE_ECU_BATTERY_SW_VERSIONS_FILE)
+        elif file == "ENGINE":
+            folder_data = self.__getFilesFromFolder(DRIVE_ECU_ENGINE_SW_VERSIONS_FILE)
+        elif file == "DOORS":
+            folder_data = self.__getFilesFromFolder(DRIVE_ECU_DOORS_SW_VERSIONS_FILE)
+        elif file == "HVAC":
+            folder_data = self.__getFilesFromFolder(DRIVE_ECU_HVAC_SW_VERSIONS_FILE)
+        
+        if folder_data :
+            for file in folder_data['files']:
+                
+                json_file = {
+                    'name': file['name'],
+                    'id': file['id'],
+                    'type': self.__getFileType(file),
+                    'size' : file.get('size', 'N/A'),
+                    'size_uncompressed' : file.get('appProperties', {}).get('size_uncompressed', 0),
+                    'sw_version': self.__getSoftwareVersion(file['name']),
+                }
+                self.__drive_data_array.append(json_file)
+                json_files['versions'].append(json_file)
+        else:
+            json_files = self.getDriveData()
+
+        return json_files
 
 
 # Object to be imported in other modules

--- a/rest_api/actions/read_info_action.py
+++ b/rest_api/actions/read_info_action.py
@@ -80,7 +80,7 @@ class ReadInfo(Action):
 
         Endpoint test (external flow):
 
-        curl -X GET "http://127.0.0.1:5000/api/read_info_battery?is_manual_flow=false" -H "Content-Type: application/json"
+        curl -X GET "http://127.0.0.1:5000/api/read_info_battery?is_manual_flow=false&item=percentage" -H "Content-Type: application/json"
 
         """
         try:

--- a/rest_api/actions/request_id_action.py
+++ b/rest_api/actions/request_id_action.py
@@ -27,7 +27,7 @@ class IDsToJson():
 
 
 class RequestIdAction(Action):
-    """ curl -X GET http://127.0.0.1:5000/api/request_ids """
+    """ curl -X GET http://127.0.0.1:5000/api/request_ids?is_manual_flow=false """
     def __init__(self):
         super().__init__()
 

--- a/rest_api/routes/api.py
+++ b/rest_api/routes/api.py
@@ -169,12 +169,22 @@ def get_logs():
     response = log_memory
     return jsonify({'logs': response})
 
+@api_bp.route('/drive_update_data', defaults={'parameter': None}, methods=['GET'], strict_slashes=False)
+@api_bp.route('/drive_update_data/<string:parameter>', methods=['GET'], strict_slashes=False)
+def update_drive_data(parameter):
+    """ curl -X GET http://127.0.0.1:5000/api/drive_update_data/mcu """
+    if parameter:
+        parameter = parameter.upper()
+        drive_data_json = gDrive.getDriveData_from_ECU(parameter)
+        return jsonify(drive_data_json)
+    else:
+        drive_data_json = gDrive.getDriveData()
 
-@api_bp.route('/drive_update_data', methods=['GET'])
-def update_drive_data():
-    """ curl -X GET http://127.0.0.1:5000/api/drive_update_data """
-    drive_data_json = gDrive.getDriveData()
-    return jsonify(drive_data_json)
+    if drive_data_json:
+        return jsonify(drive_data_json)
+    else:
+        return jsonify({'error': 'No data found'}), 404
+    
 
 
 @api_bp.route('/authenticate', methods=['GET'])


### PR DESCRIPTION
## Description

The problem seems to be from the connection between google drive and api. Every time we request versions from google drive we do it for all ecu's at once. It loads the request for google and information is lost.

The problem has been solved
For a faster response speed I recommend using the normal route /drive_update_data/<parameter>

You can still use /drive_update_data/ but you will load the API server and the response will be delayed.

You can use the following routes to check the drive versions like this:
/api/drive_update_data/mcu
/api/drive_update_data/battery
/api/drive_update_data/engine
/api/drive_update_data/doors
/api/drive_update_data/hvac

It doesn't matter if the parameter is written in lowercase or uppercase, the API will know what you are referring to.
If you don't use some of these parameters and enter other parameters the response will be exactly the same as if you had called:
/api/drive_update_data/

## Trello link [here](https://trello.com/c/HcVoHxLE)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
