### PR TITLE
Feature/fix request update status uts

### DIFF
--- a/ota/request_update_status/src/RequestUpdateStatus.cpp
+++ b/ota/request_update_status/src/RequestUpdateStatus.cpp
@@ -52,6 +52,11 @@ std::vector<uint8_t> RequestUpdateStatus::requestUpdateStatus(canid_t request_id
     if(RIDB_response[1] == NEGATIVE_RESPONSE)
     {
         nrc.sendNRC(response_id, REQUEST_UPDATE_STATUS_SID, RIDB_response[3]);
+        /* Return the negative response from the request update status */
+        response.push_back(REQUEST_UPDATE_STATUS_RESPONSE_NEGATIVE_SIZE); /* RESPONSE NEGATIVE SIZE = 0X04 */
+        response.push_back(NEGATIVE_RESPONSE); /* NEGATIVE RESPONSE = 0X7F*/
+        response.push_back(REQUEST_UPDATE_STATUS_SID); /* SID RETURNED ON FAILURE */
+        response.push_back(RIDB_response[3]);
         AccessTimingParameter::stopTimingFlag(receiver_byte, REQUEST_UPDATE_STATUS_SID);
         return response;
     }
@@ -63,13 +68,19 @@ std::vector<uint8_t> RequestUpdateStatus::requestUpdateStatus(canid_t request_id
             LOG_WARN(_logger.GET_LOGGER(), "Status value {} read from readDataByIdentifier is invalid.", status);
             nrc.sendNRC(response_id, REQUEST_UPDATE_STATUS_SID, NegativeResponse::ROOR);
             AccessTimingParameter::stopTimingFlag(receiver_byte, REQUEST_UPDATE_STATUS_SID);
+
+            /* Return the negative response from the request update status */
+            response.push_back(REQUEST_UPDATE_STATUS_RESPONSE_NEGATIVE_SIZE); /* RESPONSE NEGATIVE SIZE = 0X04 */
+            response.push_back(NEGATIVE_RESPONSE); /* NEGATIVE RESPONSE = 0X7F*/
+            response.push_back(REQUEST_UPDATE_STATUS_SID); /* SID RETURNED ON FAILURE */
+            response.push_back(REQUEST_OUT_OF_RANGE); /* SAME AS NegativeResponse::ROOR */
             return response;
         }
         else
         {
             /* Everything ok, Ota Update Status received*/
-            response.push_back(PCI_L);                              /* PCI_l */
-            response.push_back(REQUEST_UPDATE_STATUS_SID_SUCCESS);  /* SERVICE SUCCESs = SID + 0X40 */
+            response.push_back(REQUEST_UPDATE_STATUS_RESPONSE_SUCCESS_SIZE);  /* RESPONSE SUCCESS SIZE = 0X03 */
+            response.push_back(REQUEST_UPDATE_STATUS_SID_SUCCESS);  /* SERVICE SUCCESS = SID + 0X40 */
             response.push_back(status);                   /* OTA UPDATE STATUS */
         }
     }
@@ -85,7 +96,7 @@ bool RequestUpdateStatus::isValidStatus(uint8_t status)
 {
     std::vector<OtaUpdateStatesEnum> valid_states{IDLE,INIT,READY,PROCESSING,PROCESSING_TRANSFER_COMPLETE,PROCESSING_TRANSFER_FAILED,
                                                     WAIT,WAIT_DOWNLOAD_COMPLETED,WAIT_DOWNLOAD_FAILED,VERIFY, VERIFY_COMPLETE, VERIFY_FAILED,
-                                                    ACTIVATE,ACTIVATE_INSTALL_COMPLETE,ACTIVATE_INSTALL_FAILED,ERROR};
+                                                    ACTIVATE,ACTIVATE_INSTALL_COMPLETE,ACTIVATE_INSTALL_FAILED};
     /* Check if provided status from readDataByIdentifier is a valid one. */
     for(auto &state : valid_states)
     {

--- a/ota/request_update_status/utest/RequestUpdateStatusTest.cpp
+++ b/ota/request_update_status/utest/RequestUpdateStatusTest.cpp
@@ -1,19 +1,33 @@
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <memory>
+#include <iostream>
 #include "../include/RequestUpdateStatus.h"
 #include "../../../uds/access_timing_parameters/include/AccessTimingParameter.h"
+#include "../../../utils/include/CaptureFrame.h"
 #include "../../../uds/write_data_by_identifier/include/WriteDataByIdentifier.h"
 #include "../../../mcu/include/MCUModule.h"
 #include "../../../utils/include/NegativeResponse.h"
+#include "../../../uds/authentication/include/SecurityAccess.h"
+#include "../../../utils/include/TestUtils.h"
 
 class RequestUpdateStatusTest : public ::testing::Test {
 protected:
-    int socket_id = 2;
+    int socket_id;
+    int socket_id2;
     Logger logger;
     RequestUpdateStatus RUS = RequestUpdateStatus(socket_id, logger);
+    std::shared_ptr<SecurityAccess> spSecurityAccess;
+    std::shared_ptr<CaptureFrame> spCapturedFrame;
 
     RequestUpdateStatusTest()
     {
+        v_loadProjectPath();
+        socket_id = createSocket(0);
+        socket_id2 = createSocket(0);
+        spSecurityAccess = std::make_shared<SecurityAccess>(socket_id,logger);
+        spCapturedFrame = std::make_shared<CaptureFrame>(socket_id2);
         MCU::mcu = new MCU::MCUModule(0x01);
     }
     
@@ -50,11 +64,36 @@ TEST_F(RequestUpdateStatusTest, StatusInvalidTest)
 }
 
 /**
+ * @brief Test if a negative response is sent in case of an invalid status.
+ * 
+ */
+TEST_F(RequestUpdateStatusTest, NegativeResponseInvalidStatusTest)
+{
+    int request_id = 0x0000fa10; 
+    uint8_t invalid_status = ERROR;
+
+    WriteDataByIdentifier WDBI(logger, socket_id);
+    WDBI.WriteDataByIdentifierService(request_id, {PCI_L, WRITE_DATA_BY_IDENTIFIER_SID, OTA_UPDATE_STATUS_DID_MSB, OTA_UPDATE_STATUS_DID_LSB, invalid_status});
+
+    std::vector<uint8_t> request = {PCI_L, REQUEST_UPDATE_STATUS_SID};
+    std::vector<uint8_t> response = RUS.requestUpdateStatus(request_id, request);
+
+    std::vector<uint8_t> expected_response = {REQUEST_UPDATE_STATUS_RESPONSE_NEGATIVE_SIZE, NEGATIVE_RESPONSE, REQUEST_UPDATE_STATUS_SID, NegativeResponse::SAD};
+    
+    EXPECT_EQ(response.size(), expected_response.size());
+    for(uint8_t index = 0; index <= expected_response.size() - 1; index++)
+    {
+        EXPECT_EQ(response[index], expected_response[index]);
+    }
+}
+
+/**
  * @brief Test if a wrong request id is redirected to the right one (caller API, receiver MCU)
  * 
  */
 TEST_F(RequestUpdateStatusTest, WrongSenderReceiverCheckTest)
 {
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, REQUEST_UPDATE_STATUS_SID);
     int request_id = 0x00001011;
     std::vector<uint8_t> request = {PCI_L, REQUEST_UPDATE_STATUS_SID};
     std::vector<uint8_t> response = RUS.requestUpdateStatus(request_id, request);
@@ -75,6 +114,7 @@ TEST_F(RequestUpdateStatusTest, WrongSenderReceiverCheckTest)
  */
 TEST_F(RequestUpdateStatusTest, InitialOtaStatusTest)
 {
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, REQUEST_UPDATE_STATUS_SID);
     int request_id = 0x0000fa10;
     std::vector<uint8_t> request = {PCI_L, REQUEST_UPDATE_STATUS_SID};
     std::vector<uint8_t> response = RUS.requestUpdateStatus(request_id, request);
@@ -94,6 +134,7 @@ TEST_F(RequestUpdateStatusTest, InitialOtaStatusTest)
  */
 TEST_F(RequestUpdateStatusTest, AfterStatusUpdateTest)
 {
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, REQUEST_UPDATE_STATUS_SID);
     int request_id = 0x0000fa10;
     uint8_t new_status = WAIT;
 
@@ -116,10 +157,11 @@ TEST_F(RequestUpdateStatusTest, AfterStatusUpdateTest)
  * @brief Test if a negative response is sent in case of an invalid status.
  * 
  */
-TEST_F(RequestUpdateStatusTest, NegativeResponseInvalidStatusTest)
+TEST_F(RequestUpdateStatusTest, PositiveResponseInvalidStatusTest)
 {
+    v_requestSecurityAccess(spSecurityAccess, spCapturedFrame, REQUEST_UPDATE_STATUS_SID);
     int request_id = 0x0000fa10;
-    uint8_t invalid_status = 0xFF;
+    uint8_t invalid_status = ERROR;
 
     WriteDataByIdentifier WDBI(logger, socket_id);
     WDBI.WriteDataByIdentifierService(request_id, {PCI_L, WRITE_DATA_BY_IDENTIFIER_SID, OTA_UPDATE_STATUS_DID_MSB, OTA_UPDATE_STATUS_DID_LSB, invalid_status});
@@ -127,7 +169,7 @@ TEST_F(RequestUpdateStatusTest, NegativeResponseInvalidStatusTest)
     std::vector<uint8_t> request = {PCI_L, REQUEST_UPDATE_STATUS_SID};
     std::vector<uint8_t> response = RUS.requestUpdateStatus(request_id, request);
 
-    std::vector<uint8_t> expected_response = {PCI_L, NEGATIVE_RESPONSE, REQUEST_UPDATE_STATUS_SID, REQUEST_OUT_OF_RANGE};
+    std::vector<uint8_t> expected_response = {REQUEST_UPDATE_STATUS_RESPONSE_NEGATIVE_SIZE, NEGATIVE_RESPONSE, REQUEST_UPDATE_STATUS_SID, REQUEST_OUT_OF_RANGE};
     
     EXPECT_EQ(response.size(), expected_response.size());
     for(uint8_t index = 0; index <= expected_response.size() - 1; index++)


### PR DESCRIPTION
## Description

The following errors inside of the request update status service were fixed in this PR:

1. Missing response when negative response was returned by read data by identifier
2. Missing response when received status was invalid
3. Removed Error from isValidStatus

Additionally, the follosing changes were done in the requestUpdateStatusTests:

1. Added a separate socket for the captured frame
2. Added a security access object. Together with the captured frame, they are used inside of the calls to the request security access function
3. Added calls to requestSecurityAccess in the tests to avoid premature failure due to security access denied
4. The current UT NegativeResponseInvalidStatusTest was renamed to PositiveResponseInvalidStatusTest as the received respnes from RDBI was not negative. Additionally, a new NegativeResponseInvalidStatusTest was created to cover the case when RDBI returns a negative response

All tests pass and coverage is 100% (see the attached ticket

## Trello link [here](https://trello.com/c/M90hiITx/42-rework-tests-for-request-update-status)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
