### PR TITLE
chore: add allPreProcess target

### DIFF
--- a/mcu/Makefile
+++ b/mcu/Makefile
@@ -66,8 +66,7 @@ OBJ_DIR = obj
 HVAC_DIR_TEST = ../ecu_simulation/HVACModule/test
 
 # Build config
-all:
-	$(MAKE) -C ../config init
+all: allPreProcess
 
 #----------------------------------------------------MCU MODULE-----------------------------------------------------
 
@@ -508,6 +507,7 @@ cleanAllTests: cleanMcuModuleTest cleanBatteryModuleTest cleanEngineModuleTest c
 runHandleFramesTest: handleFramesTest
 	$(UTILS_TEST)/handleFramesTest.out
 
+handleFramesTest: allPreProcess
 handleFramesTest: $(OBJ_DIR) $(UTILS_TEST)/handleFramesTest.out
 
 $(UTILS_TEST)/handleFramesTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/HandleFrames_test.o
@@ -523,6 +523,7 @@ cleanHandleFramesTest:
 	rm -rf $(UTILS_TEST)/*.gcda
 
 # FileManager Unit tests
+fileManagerTest: allPreProcess
 fileManagerTest: $(OBJ_DIR) $(UTILS_TEST)/fileManagerTest.out
 
 $(UTILS_TEST)/fileManagerTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/FileManager_test.o
@@ -535,6 +536,7 @@ $(UTILS_TEST)/FileManager_test.o: $(UTILS_TEST)/FileManagerTest.cpp
 runEcuTest: ecuTest
 	$(UTILS_TEST)/ecuTest.out
 
+ecuTest: allPreProcess
 ecuTest: $(OBJ_DIR) $(UTILS_TEST)/ecuTest.out
 
 $(UTILS_TEST)/ecuTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/ECU_test.o
@@ -553,6 +555,7 @@ cleanEcuTest:
 runReceiveFramesTestUtils: receiveFramesTestUtils
 	$(UTILS_TEST)/receiveFramesTestUtils.out
 
+receiveFramesTestUtils: allPreProcess
 receiveFramesTestUtils: $(OBJ_DIR) $(UTILS_TEST)/receiveFramesTestUtils.out
 
 $(UTILS_TEST)/receiveFramesTestUtils.out: $(OBJ_DIR) $(OBJS_TEST) $(UTILS_TEST)/ReceiveFrames_test_utils.o
@@ -572,6 +575,7 @@ cleanReceiveFramesTestUtils:
 runReceiveFramesTest: receiveFramesTest
 	$(SRC_TEST)/receiveFramesTest.out
 
+receiveFramesTest: allPreProcess
 receiveFramesTest: $(OBJ_DIR) $(SRC_TEST)/receiveFramesTest.out
 
 $(SRC_TEST)/receiveFramesTest.out: $(OBJ_DIR) $(OBJS_TEST) $(SRC_TEST)/ReceiveFrames_test.o
@@ -591,6 +595,7 @@ cleanReceiveFramesTest:
 runMcuModuleTest: mcuModuleTest
 	$(SRC_TEST)/mcuModuleTest.out
 
+mcuModuleTest: allPreProcess
 mcuModuleTest: $(OBJ_DIR) $(SRC_TEST)/mcuModuleTest.out
 
 $(SRC_TEST)/mcuModuleTest.out: $(OBJ_DIR) $(OBJS_TEST) $(SRC_TEST)/MCUModule_test.o
@@ -610,6 +615,7 @@ cleanMcuModuleTest:
 runGenerateFramesTest: generateFramesTest
 	$(UTILS_TEST)/generateFramesTest.out
 
+generateFramesTest: allPreProcess
 generateFramesTest: $(OBJ_DIR) $(UTILS_TEST)/generateFramesTest.out
 
 $(UTILS_TEST)/generateFramesTest.out: $(OBJ_DIR) $(OBJS_GENERATE_TEST) $(UTILS_TEST)/GenerateFrames_test.o
@@ -629,6 +635,7 @@ cleanGenerateFramesTest:
 runLoggerTest: loggerTest
 	$(UTILS_TEST)/loggerTest.out
 
+loggerTest: allPreProcess
 loggerTest: $(OBJ_DIR) $(UTILS_TEST)/loggerTest.out
 
 $(UTILS_TEST)/loggerTest.out: $(OBJ_DIR) $(OBJS_LOGGER_TEST) $(UTILS_TEST)/Logger_test.o
@@ -648,6 +655,7 @@ cleanLoggerTest:
 runMemoryManagerTest: memoryManagerTest
 	$(UTILS_TEST)/memoryManagerTest.out
 
+memoryManagerTest: allPreProcess
 memoryManagerTest: $(OBJ_DIR) $(UTILS_TEST)/memoryManagerTest.out
 
 $(UTILS_TEST)/memoryManagerTest.out: $(OBJ_DIR) $(OBJS_MEMORY_TEST) $(UTILS_TEST)/MemoryManager_test.o
@@ -667,6 +675,7 @@ cleanMemoryManagerTest:
 runCreateInterfaceTest: createInterfaceTest
 	$(UTILS_TEST)/createInterfaceTest.out
 
+createInterfaceTest: allPreProcess
 createInterfaceTest: $(OBJ_DIR) $(UTILS_TEST)/createInterfaceTest.out
 
 $(UTILS_TEST)/createInterfaceTest.out: $(OBJ_DIR) $(OBJS_CREATEINTERFACE_TEST) $(UTILS_TEST)/CreateInterface_test.o
@@ -686,6 +695,7 @@ cleanCreateInterfaceTest:
 runDiagnosticSessionControlTest: diagnosticSessionControlTest
 	$(UDS_DIR)/diagnostic_session_control/utest/diagnosticSessionControlTest.out
 
+diagnosticSessionControlTest: allPreProcess
 diagnosticSessionControlTest: $(OBJ_DIR) $(UDS_DIR)/diagnostic_session_control/utest/diagnosticSessionControlTest.out
 
 $(UDS_DIR)/diagnostic_session_control/utest/diagnosticSessionControlTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/diagnostic_session_control/utest/DiagnosticSessionControl_test.o
@@ -705,6 +715,7 @@ cleanDiagnosticSessionControlTest:
 runReadMemoryByAddressTest: readMemoryByAddressTest
 	$(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out
 
+readMemoryByAddressTest: allPreProcess
 readMemoryByAddressTest: $(OBJ_DIR) $(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out
 
 $(UDS_DIR)/read_memory_by_address/utest/readMemoryByAddressTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/read_memory_by_address/utest/ReadMemoryByAddress_test.o
@@ -724,6 +735,7 @@ cleanReadMemoryByAddressTest:
 runWriteDataByIdentifierTest: writeDataByIdentifierTest
 	$(UDS_DIR)/write_data_by_identifier/utest/writeDataByIdentifierTest.out
 
+writeDataByIdentifierTest: allPreProcess
 writeDataByIdentifierTest: $(OBJ_DIR) $(UDS_DIR)/write_data_by_identifier/utest/writeDataByIdentifierTest.out
 
 $(UDS_DIR)/write_data_by_identifier/utest/writeDataByIdentifierTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/write_data_by_identifier/utest/WriteDataByIdentifier_test.o
@@ -743,6 +755,7 @@ cleanWriteDataByIdentifierTest:
 runReadDataByIdentifierTest: readDataByIdentifierTest
 	$(UDS_DIR)/read_data_by_identifier/utest/readDataByIdentifierTest.out
 
+readDataByIdentifierTest: allPreProcess
 readDataByIdentifierTest: $(OBJ_DIR) $(UDS_DIR)/read_data_by_identifier/utest/readDataByIdentifierTest.out
 
 $(UDS_DIR)/read_data_by_identifier/utest/readDataByIdentifierTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/read_data_by_identifier/utest/ReadDataByIdentifier_test.o
@@ -762,6 +775,7 @@ cleanReadDataByIdentifierTest:
 runRequestTransferExitTest: requestTransferExitTest
 	$(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out
 
+requestTransferExitTest: allPreProcess
 requestTransferExitTest: $(OBJ_DIR) $(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out
 
 $(OTA_DIR)/request_transfer_exit/utest/requestTransferExitTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_transfer_exit/utest/RequestTransferExit_test.o
@@ -781,6 +795,7 @@ cleanRequestTransferExitTest:
 runReadDtcTest: readDtcTest
 	$(UDS_DIR)/read_dtc_information/utest/readDtcTest.out
 
+readDtcTest: allPreProcess
 readDtcTest: $(OBJ_DIR) $(UDS_DIR)/read_dtc_information/utest/readDtcTest.out
 
 $(UDS_DIR)/read_dtc_information/utest/readDtcTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/read_dtc_information/utest/ReadDtcInformation_test.o
@@ -800,6 +815,7 @@ cleanReadDtcTest:
 runClearDtcTest: clearDtcTest
 	$(UDS_DIR)/clear_dtc/utest/clearDtcTest.out
 
+clearDtcTest: allPreProcess
 clearDtcTest: $(OBJ_DIR) $(UDS_DIR)/clear_dtc/utest/clearDtcTest.out
 
 $(UDS_DIR)/clear_dtc/utest/clearDtcTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/clear_dtc/utest/ClearDtc_test.o
@@ -819,6 +835,7 @@ cleanClearDtcTest:
 runRequestUpdateStatusTest: requestUpdateStatusTest
 	$(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out
 
+requestUpdateStatusTest: allPreProcess
 requestUpdateStatusTest: $(OBJ_DIR) $(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out
 
 $(OTA_DIR)/request_update_status/utest/requestUpdateStatusTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_update_status/utest/RequestUpdateStatus_test.o
@@ -838,6 +855,7 @@ cleanRequestUpdateStatusTest:
 runSecurityAccessTest: securityAccessTest
 	$(UDS_DIR)/authentication/utest/securityAccessTest.out
 
+securityAccessTest: allPreProcess
 securityAccessTest: $(OBJ_DIR) $(UDS_DIR)/authentication/utest/securityAccessTest.out
 
 $(UDS_DIR)/authentication/utest/securityAccessTest.out: $(OBJ_DIR) $(OBJS_SECURITYACCESS_TEST) $(UDS_DIR)/authentication/utest/SecurityAccess_test.o
@@ -857,6 +875,7 @@ cleanSecurityAccessTest:
 runTesterPresentTest: testerPresentTest
 	$(UDS_DIR)/tester_present/utest/testerPresentTest.out
 
+testerPresentTest: allPreProcess
 testerPresentTest: $(OBJ_DIR) $(UDS_DIR)/tester_present/utest/testerPresentTest.out
 
 $(UDS_DIR)/tester_present/utest/testerPresentTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/tester_present/utest/TesterPresent_test.o
@@ -876,6 +895,7 @@ cleanTesterPresentTest:
 runRoutineControlTest: routineControlTest
 	$(UDS_DIR)/routine_control/utest/routineControlTest.out
 
+routineControlTest: allPreProcess
 routineControlTest: $(OBJ_DIR) $(UDS_DIR)/routine_control/utest/routineControlTest.out
 
 $(UDS_DIR)/routine_control/utest/routineControlTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/routine_control/utest/RoutineControl_test.o
@@ -895,6 +915,7 @@ cleanRoutineControlTest:
 runEcuResetTest: ecuResetTest
 	$(UDS_DIR)/ecu_reset/utest/ecuResetTest.out
 
+ecuResetTest: allPreProcess
 ecuResetTest: $(OBJ_DIR) $(UDS_DIR)/ecu_reset/utest/ecuResetTest.out
 
 $(UDS_DIR)/ecu_reset/utest/ecuResetTest.out: $(OBJ_DIR) $(OBJS_TEST) $(UDS_DIR)/ecu_reset/utest/EcuReset_test.o
@@ -914,6 +935,7 @@ cleanEcuResetTest:
 runDoorsModuleTest: doorsModuleTest
 	$(DOORS_DIR_TEST)/doorsModuleTest.out
 
+doorsModuleTest: allPreProcess
 doorsModuleTest: $(OBJ_DIR) $(DOORS_DIR_TEST)/doorsModuleTest.out
 
 $(DOORS_DIR_TEST)/doorsModuleTest.out: $(OBJ_DIR) $(DOORS_DIR_TEST)/doorsModule_test.o $(OBJS_TEST)
@@ -933,6 +955,7 @@ cleanDoorsModuleTest:
 runRequestDownloadTest: requestDownloadTest
 	$(OTA_DIR)/request_download/utest/requestDownloadTest.out
 
+requestDownloadTest: allPreProcess
 requestDownloadTest: $(OBJ_DIR) $(OTA_DIR)/request_download/utest/requestDownloadTest.out
 
 $(OTA_DIR)/request_download/utest/requestDownloadTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/request_download/utest/RequestDownload_test.o
@@ -952,6 +975,7 @@ cleanRequestDownloadTest:
 runTransferDataTest: transferDataTest
 	$(OTA_DIR)/transfer_data/utest/transferDataTest.out
 
+transferDataTest: allPreProcess
 transferDataTest: $(OBJ_DIR) $(OTA_DIR)/transfer_data/utest/transferDataTest.out
 
 $(OTA_DIR)/transfer_data/utest/transferDataTest.out: $(OBJ_DIR) $(OBJS_TEST) $(OTA_DIR)/transfer_data/utest/TransferData_test.o
@@ -971,6 +995,7 @@ cleanTransferDataTest:
 runHvacModuleTest: hvacModuleTest
 	$(HVAC_DIR_TEST)/hvacModuleTest.out
 
+hvacModuleTest: allPreProcess
 hvacModuleTest: $(OBJ_DIR) $(HVAC_DIR_TEST)/hvacModuleTest.out
 
 $(HVAC_DIR_TEST)/hvacModuleTest.out: $(OBJ_DIR) $(HVAC_DIR_TEST)/hvacModule_test.o $(OBJS_TEST)
@@ -990,6 +1015,7 @@ cleanHvacModuleTest:
 runAccessTimingParameterTest: accessTimingParameterTest
 	$(UDS_DIR)/access_timing_parameters/utest/accessTimingParameterTest.out
 
+accessTimingParameterTest: allPreProcess
 accessTimingParameterTest: $(OBJ_DIR) $(UDS_DIR)/access_timing_parameters/utest/accessTimingParameterTest.out
 
 $(UDS_DIR)/access_timing_parameters/utest/accessTimingParameterTest.out: $(UDS_DIR) $(OBJS_TEST) $(UDS_DIR)/access_timing_parameters/utest/AccessTimingParameter_test.o
@@ -1009,6 +1035,7 @@ cleanAccessTimingParameterTest:
 runEngineModuleTest: engineModuleTest
 	$(ENGINE_DIR_TEST)/engineModuleTest.out
 
+engineModuleTest: allPreProcess
 engineModuleTest: $(OBJ_DIR) $(ENGINE_DIR_TEST)/engineModuleTest.out
 
 $(ENGINE_DIR_TEST)/engineModuleTest.out: $(OBJ_DIR) $(ENGINE_DIR_TEST)/engineModule_test.o $(OBJS_TEST)
@@ -1028,6 +1055,7 @@ cleanEngineModuleTest:
 runNegativeResponseTest: negativeResponseTest
 	$(UTILS_TEST)/negativeResponseTest.out
 
+negativeResponseTest: allPreProcess
 negativeResponseTest: $(OBJ_DIR) $(UTILS_TEST)/negativeResponseTest.out
 
 $(UTILS_TEST)/negativeResponseTest.out: $(OBJ_DIR) $(OBJS_NEGATIVERESPONSE_TEST) $(UTILS_TEST)/NegativeResponse_test.o
@@ -1047,6 +1075,7 @@ cleanNegativeResponseTest:
 runBatteryModuleTest: batteryModuleTest
 	$(BATTERY_DIR_TEST)/batteryModuleTest.out
 
+batteryModuleTest: allPreProcess
 batteryModuleTest: $(OBJ_DIR) $(BATTERY_DIR_TEST)/batteryModuleTest.out
 
 $(BATTERY_DIR_TEST)/batteryModuleTest.out: $(OBJ_DIR) $(BATTERY_DIR_TEST)/batteryModule_test.o $(OBJS_TEST)
@@ -1551,6 +1580,10 @@ allCoveragePostProcess:
 	find . -name '*.info' -delete
 
 allCoverage: allCoveragePostProcess
+
+# Preprocess target
+allPreProcess:
+	$(MAKE) -C ../config init
 
 #----------------------------------------------------Clean up--------------------------------------------------------
 


### PR DESCRIPTION
## Description

The creation of the config.ini file was limited to the all make target. This PR proposes the introduction of a new target, allPreProcess, which will create the config.ini (named allPreProcess in case any other tasks are to be added to this target). This target is built when making all, or any standalone test executable (used also by allTests, the run targets and the coverage targets).
The job was not deemed necessary for the clean tasks nor was it necessary to be added to the Ecu modules' makefiles.

I tested this change as follows:

1. To ensure how many times the allPreProcess job should appear in the makefile, I counted how many test targets there are in allTests (I also added the fileManagerTests which is currently missing but will be added when merging this PR: https://github.com/GeorgeCimpoeru/backend_repo/pull/67): in total there are 30 test targets; therefore, the allPreProcess job had to appear 32 times in the Makefile (once per test target, plus the definition and the dependency for all)
2. To ensure that it works i randomly selected 3 targets and ran a standard test compilation, a run target and a coverage target. In all cases, the config.ini file is created and the job is completed as expected

## Trello link [here](https://trello.com/c/AxYZ0ERf/84-configini-created-only-by-make-all)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
